### PR TITLE
Feature/run targets as basic tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,6 @@ script:
   - mkdir build && cd build
   - cmake -DCMAKE_CXX_COMPILER=$COMP_CPP ..
   - cmake --build .
+  - ./ganon-build
+  - ./ganon-classify
+  - ./ganon-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 language: cpp
 
-sudo: required
-dist: trusty
-
-before_install:
-  - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
-  - sudo -E apt-get update -qq
-  - sudo -E apt-get install g++-7 -y
-  - export COMP_CPP=$(which g++-7)
+matrix:
+  include:
+    - name: "g++-7"
+      os: linux
+      dist: trusty
+      sudo: required
+      compiler: gcc
+      addons:
+        apt:
+          sources: ubuntu-toolchain-r-test
+          packages: g++-7
+      env: COMP_CPP=g++-7
 
 script:
   - mkdir build && cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ dist: trusty
 before_install:
   - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
   - sudo -E apt-get update -qq
-  - sudo -E apt-get install gcc-7 g++-7 -y
+  - sudo -E apt-get install g++-7 -y
   - export COMP_CPP=$(which g++-7)
 
 script:
   - mkdir build && cd build
   - cmake -DCMAKE_CXX_COMPILER=$COMP_CPP ..
-  - cmake --build . #=make
+  - cmake --build .

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ matrix:
       os: linux
       dist: trusty
       sudo: required
-      compiler: gcc
       addons:
         apt:
           sources: ubuntu-toolchain-r-test

--- a/ganon-build.cpp
+++ b/ganon-build.cpp
@@ -45,7 +45,7 @@ int main(int argc, char* argv[]){
 
     if(args.count("help") || old_argc<=1){
         std::cerr << options.help() << std::endl;
-        return 0;
+        return 1;
     }else if(args.count("version")){
         std::cerr << "version" << std::endl;
         return 0;

--- a/ganon-build.cpp
+++ b/ganon-build.cpp
@@ -45,7 +45,7 @@ int main(int argc, char* argv[]){
 
     if(args.count("help") || old_argc<=1){
         std::cerr << options.help() << std::endl;
-        return 1;
+        return 0;
     }else if(args.count("version")){
         std::cerr << "version" << std::endl;
         return 0;


### PR DESCRIPTION
Main changes:

1. run binaries for usage message as a crude test
2. remove gcc-7 (let any dependency explicitly ask for this before installing)
3. use travis build matrix structure (this will make it easier to add other build plans)