### PR TITLE
Feature/add clang support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,24 @@ language: cpp
 
 matrix:
   include:
-    - name: "g++-7"
+    - name: "linux gcc-7"
       os: linux
       dist: trusty
-      sudo: required
       addons:
         apt:
-          sources: ubuntu-toolchain-r-test
-          packages: g++-7
-      env: COMP_CPP=g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+before_install:
+  - eval "${MATRIX_EVAL}"
 
 script:
   - mkdir build && cd build
-  - cmake -DCMAKE_CXX_COMPILER=$COMP_CPP -DVERBOSE_CONFIG=ON ..
+  - cmake -DCMAKE_BUILD_TYPE=Release -DVERBOSE_CONFIG=ON ..
   - cmake --build .
   - ./ganon-build
   - ./ganon-classify

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 language: cpp
 
 matrix:
-  include:
-    - name: "linux gcc-7"
-      os: linux
-      dist: trusty
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
-      env:
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+#  include:
+#    - name: "linux gcc-7"
+#      os: linux
+#      dist: trusty
+#      addons:
+#        apt:
+#          sources:
+#            - ubuntu-toolchain-r-test
+#          packages:
+#            - g++-7
+#      env:
+#        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
 
     - name: "linux clang-6"
       os: linux
@@ -31,7 +31,7 @@ before_install:
 
 script:
   - mkdir build && cd build
-  - cmake -DCMAKE_BUILD_TYPE=Release -DVERBOSE_CONFIG=ON ..
+  - cmake -DCMAKE_BUILD_TYPE=Release -DVERBOSE_CONFIG=ON -DCMAKE_CXX_FLAGS="-stdlib=libc++" ..
   - cmake --build .
   - ./ganon-build
   - ./ganon-classify

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,18 @@ matrix:
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
 
+    - name: "linux clang-6"
+      os: linux
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-6.0
+          packages:
+            - clang-6.0
+      env:
+        - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
+
 before_install:
   - eval "${MATRIX_EVAL}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 language: cpp
 
 matrix:
-#  include:
-#    - name: "linux gcc-7"
-#      os: linux
-#      dist: trusty
-#      addons:
-#        apt:
-#          sources:
-#            - ubuntu-toolchain-r-test
-#          packages:
-#            - g++-7
-#      env:
-#        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+  include:
+    - name: "linux gcc-7"
+      os: linux
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
 
     - name: "linux clang-6"
       os: linux
@@ -20,8 +20,10 @@ matrix:
       addons:
         apt:
           sources:
+            - ubuntu-toolchain-r-test
             - llvm-toolchain-trusty-6.0
           packages:
+            - g++-7 # for libstdc++ dependency
             - clang-6.0
       env:
         - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
@@ -31,7 +33,7 @@ before_install:
 
 script:
   - mkdir build && cd build
-  - cmake -DCMAKE_BUILD_TYPE=Release -DVERBOSE_CONFIG=ON -DCMAKE_CXX_FLAGS="-stdlib=libc++" ..
+  - cmake -DCMAKE_BUILD_TYPE=Release -DVERBOSE_CONFIG=ON ..
   - cmake --build .
   - ./ganon-build
   - ./ganon-classify

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
 
 script:
   - mkdir build && cd build
-  - cmake -DCMAKE_CXX_COMPILER=$COMP_CPP ..
+  - cmake -DCMAKE_CXX_COMPILER=$COMP_CPP -DVERBOSE_CONFIG=ON ..
   - cmake --build .
   - ./ganon-build
   - ./ganon-classify


### PR DESCRIPTION
Adding Travis support to `clang-6.0` on `Ubuntu 14.04`.

**DETAIL:** on trusty clang-6 needs also some packages from gcc-7 for libstdc++. See https://apt.llvm.org/