### PR TITLE
Feature/remove using namespace seqan

### DIFF
--- a/src/ganon-build/ganon-build.cpp
+++ b/src/ganon-build/ganon-build.cpp
@@ -12,15 +12,13 @@
 #include <mutex>
 #include <vector>
 
-using namespace seqan;
-
 static const uint64_t gbInBits = 8589934592;
 
 struct SeqBin
 {
-    CharString id;
-    Dna5String seq;
-    uint64_t   bin;
+    seqan::CharString id;
+    seqan::Dna5String seq;
+    uint64_t          bin;
 };
 
 int main( int argc, char* argv[] )
@@ -103,7 +101,7 @@ int main( int argc, char* argv[] )
 
     auto start = std::chrono::high_resolution_clock::now();
 
-    KmerFilter< Dna5, InterleavedBloomFilter, Uncompressed > filter(
+    seqan::KmerFilter< seqan::Dna5, seqan::InterleavedBloomFilter, seqan::Uncompressed > filter(
         noBins, hash_functions, kmer_size, bloom_filter_size );
 
     std::chrono::duration< double > elapsed = std::chrono::high_resolution_clock::now() - start;
@@ -136,8 +134,8 @@ int main( int argc, char* argv[] )
     tasks.emplace_back( std::async( std::launch::async, [=, &bins, &q, &finished, &mtx] {
         for ( auto const& reference_fasta_file : args["references"].as< std::vector< std::string > >() )
         {
-            SeqFileIn seqFileIn;
-            if ( !open( seqFileIn, toCString( reference_fasta_file ) ) )
+            seqan::SeqFileIn seqFileIn;
+            if ( !open( seqFileIn, seqan::toCString( reference_fasta_file ) ) )
             {
                 std::cerr << "Unable to open " << reference_fasta_file << std::endl;
                 continue;
@@ -148,19 +146,19 @@ int main( int argc, char* argv[] )
                 {
                     ; // spin
                 }
-                StringSet< CharString >  ids;
-                StringSet< IupacString > seqs;
+                seqan::StringSet< seqan::CharString >  ids;
+                seqan::StringSet< seqan::IupacString > seqs;
                 readRecords( ids, seqs, seqFileIn, threads * 5 );
-                for ( uint16_t readID = 0; readID < length( ids ); ++readID )
+                for ( uint16_t readID = 0; readID < seqan::length( ids ); ++readID )
                 {
-                    if ( length( seqs[readID] ) < kmer_size )
+                    if ( seqan::length( seqs[readID] ) < kmer_size )
                     { // sequence too small
                         mtx.lock();
                         std::cerr << ids[readID] << " has sequence smaller than k-mer size" << std::endl;
                         mtx.unlock();
                         continue;
                     }
-                    std::string cid = toCString( ids[readID] );
+                    std::string cid = seqan::toCString( ids[readID] );
                     std::string acc = cid.substr( 0, cid.find( ' ' ) );
                     if ( bins.count( acc ) == 0 )
                     { // not defined on the bins
@@ -185,7 +183,7 @@ int main( int argc, char* argv[] )
     std::cerr << "Adding k-mers: " << elapsed.count() << std::endl;
 
     start = std::chrono::high_resolution_clock::now();
-    store( filter, toCString( args["output-file"].as< std::string >() ) );
+    store( filter, seqan::toCString( args["output-file"].as< std::string >() ) );
     elapsed = std::chrono::high_resolution_clock::now() - start;
     std::cerr << "Saving Bloom filter: " << elapsed.count() << std::endl;
 

--- a/src/ganon-build/ganon-build.cpp
+++ b/src/ganon-build/ganon-build.cpp
@@ -122,7 +122,7 @@ int main( int argc, char* argv[] )
                 SeqBin val = q.pop();
                 if ( val.id != "" )
                 { // if not empty
-                    insertKmer( filter, val.seq, val.bin, 0 );
+                    seqan::insertKmer( filter, val.seq, val.bin, 0 );
                 }
                 if ( finished && q.empty() )
                     break;
@@ -135,12 +135,12 @@ int main( int argc, char* argv[] )
         for ( auto const& reference_fasta_file : args["references"].as< std::vector< std::string > >() )
         {
             seqan::SeqFileIn seqFileIn;
-            if ( !open( seqFileIn, seqan::toCString( reference_fasta_file ) ) )
+            if ( !seqan::open( seqFileIn, seqan::toCString( reference_fasta_file ) ) )
             {
                 std::cerr << "Unable to open " << reference_fasta_file << std::endl;
                 continue;
             }
-            while ( !atEnd( seqFileIn ) )
+            while ( !seqan::atEnd( seqFileIn ) )
             {
                 while ( q.size() > ( threads * 10 ) )
                 {
@@ -148,7 +148,7 @@ int main( int argc, char* argv[] )
                 }
                 seqan::StringSet< seqan::CharString >  ids;
                 seqan::StringSet< seqan::IupacString > seqs;
-                readRecords( ids, seqs, seqFileIn, threads * 5 );
+                seqan::readRecords( ids, seqs, seqFileIn, threads * 5 );
                 for ( uint16_t readID = 0; readID < seqan::length( ids ); ++readID )
                 {
                     if ( seqan::length( seqs[readID] ) < kmer_size )
@@ -170,7 +170,7 @@ int main( int argc, char* argv[] )
                     q.push( SeqBin{ acc, seqs[readID], bins[acc] } );
                 }
             }
-            close( seqFileIn );
+            seqan::close( seqFileIn );
         }
         finished = true;
     } ) );
@@ -183,7 +183,7 @@ int main( int argc, char* argv[] )
     std::cerr << "Adding k-mers: " << elapsed.count() << std::endl;
 
     start = std::chrono::high_resolution_clock::now();
-    store( filter, seqan::toCString( args["output-file"].as< std::string >() ) );
+    seqan::store( filter, seqan::toCString( args["output-file"].as< std::string >() ) );
     elapsed = std::chrono::high_resolution_clock::now() - start;
     std::cerr << "Saving Bloom filter: " << elapsed.count() << std::endl;
 

--- a/src/ganon-classify/ganon-classify.cpp
+++ b/src/ganon-classify/ganon-classify.cpp
@@ -230,12 +230,12 @@ int main( int argc, char* argv[] )
             for ( auto const& reads_file : args["reads"].as< std::vector< std::string > >() )
             {
                 seqan::SeqFileIn seqFileIn;
-                if ( !open( seqFileIn, seqan::toCString( reads_file ) ) )
+                if ( !seqan::open( seqFileIn, seqan::toCString( reads_file ) ) )
                 {
                     std::cerr << "Unable to open " << reads_file << std::endl;
                     continue;
                 }
-                while ( !atEnd( seqFileIn ) )
+                while ( !seqan::atEnd( seqFileIn ) )
                 {
                     // std::cerr << queue1->size() << std::endl;
                     while ( queue1.size() > num_of_batches )
@@ -244,11 +244,11 @@ int main( int argc, char* argv[] )
                     }
                     seqan::StringSet< seqan::CharString > ids;
                     seqan::StringSet< seqan::Dna5String > seqs;
-                    readRecords( ids, seqs, seqFileIn, num_of_reads_per_batch );
+                    seqan::readRecords( ids, seqs, seqFileIn, num_of_reads_per_batch );
                     totalReads += seqan::length( ids );
                     queue1.push( ReadBatches{ ids, seqs } );
                 }
-                close( seqFileIn );
+                seqan::close( seqFileIn );
             }
             finished_read     = true;
             loading_reads_end = std::chrono::high_resolution_clock::now();
@@ -323,9 +323,9 @@ int main( int argc, char* argv[] )
 
             // bloom filter
             filterType filter;
-            retrieve( filter, seqan::toCString( bloom_filter_file_hierarchy ) );
-            filter_hierarchy.push_back(
-                Filter{ std::move( filter ), group_bin, getNumberOfBins( filter ), getKmerSize( filter ) } );
+            seqan::retrieve( filter, seqan::toCString( bloom_filter_file_hierarchy ) );
+            filter_hierarchy.push_back( Filter{
+                std::move( filter ), group_bin, seqan::getNumberOfBins( filter ), seqan::getKmerSize( filter ) } );
         }
         loading_filter_elapsed += std::chrono::high_resolution_clock::now() - loading_filter_start;
 
@@ -455,8 +455,8 @@ int main( int argc, char* argv[] )
                             }
                             else if ( hierarchy_id < hierarchy_size )
                             {
-                                appendValue( left_over_reads.ids, rb.ids[readID] );
-                                appendValue( left_over_reads.seqs, rb.seqs[readID] );
+                                seqan::appendValue( left_over_reads.ids, rb.ids[readID] );
+                                seqan::appendValue( left_over_reads.seqs, rb.seqs[readID] );
                             }
                             else if ( output_unclassified )
                             {

--- a/src/ganon-classify/ganon-classify.cpp
+++ b/src/ganon-classify/ganon-classify.cpp
@@ -12,8 +12,6 @@
 #include <map>
 #include <vector>
 
-using namespace seqan;
-
 inline uint16_t kmer_threshold( const uint16_t& readLen, const uint16_t& kmerSize, const uint16_t& max_error )
 {
     uint16_t threshold = 0;
@@ -24,8 +22,8 @@ inline uint16_t kmer_threshold( const uint16_t& readLen, const uint16_t& kmerSiz
 
 struct ReadBatches
 {
-    StringSet< CharString > ids;
-    StringSet< Dna5String > seqs;
+    seqan::StringSet< seqan::CharString > ids;
+    seqan::StringSet< seqan::Dna5String > seqs;
 };
 
 struct ReadMatch
@@ -36,7 +34,7 @@ struct ReadMatch
 
 struct ReadOut
 {
-    CharString               readID;
+    seqan::CharString        readID;
     std::vector< ReadMatch > matches;
 };
 
@@ -181,11 +179,17 @@ int main( int argc, char* argv[] )
         out.basic_ios< char >::rdbuf( std::cout.rdbuf() );
     }
 
-    typedef ModifiedString< ModifiedString< Dna5String, ModComplementDna >, ModReverse > reversedRead;
-    std::vector< std::future< void > >                                                   read_write;
-    std::atomic< uint64_t >                                                              sumReadLen      = 0;
-    std::atomic< uint64_t >                                                              classifiedReads = 0;
-    uint64_t                                                                             totalReads      = 0;
+    // clang-format off
+    typedef seqan::ModifiedString<
+                seqan::ModifiedString< seqan::Dna5String, seqan::ModComplementDna >,
+                seqan::ModReverse
+            > reversedRead;
+    // clang-format on
+
+    std::vector< std::future< void > > read_write;
+    std::atomic< uint64_t >            sumReadLen      = 0;
+    std::atomic< uint64_t >            classifiedReads = 0;
+    uint64_t                           totalReads      = 0;
 
     SafeQueue< ReadBatches > queue1;
     SafeQueue< ReadBatches > queue2;
@@ -195,7 +199,7 @@ int main( int argc, char* argv[] )
     bool                 finished_read = false;
     bool                 finished_clas = false;
 
-    typedef KmerFilter< Dna5, InterleavedBloomFilter, Uncompressed > filterType;
+    typedef seqan::KmerFilter< seqan::Dna5, seqan::InterleavedBloomFilter, seqan::Uncompressed > filterType;
     struct Filter
     {
         filterType                        bloom_filter;
@@ -225,8 +229,8 @@ int main( int argc, char* argv[] )
         std::async( std::launch::async, [=, &queue1, &finished_read, &loading_reads_end, &totalReads] {
             for ( auto const& reads_file : args["reads"].as< std::vector< std::string > >() )
             {
-                SeqFileIn seqFileIn;
-                if ( !open( seqFileIn, toCString( reads_file ) ) )
+                seqan::SeqFileIn seqFileIn;
+                if ( !open( seqFileIn, seqan::toCString( reads_file ) ) )
                 {
                     std::cerr << "Unable to open " << reads_file << std::endl;
                     continue;
@@ -238,10 +242,10 @@ int main( int argc, char* argv[] )
                     {
                         ; // spin
                     }
-                    StringSet< CharString > ids;
-                    StringSet< Dna5String > seqs;
+                    seqan::StringSet< seqan::CharString > ids;
+                    seqan::StringSet< seqan::Dna5String > seqs;
                     readRecords( ids, seqs, seqFileIn, num_of_reads_per_batch );
-                    totalReads += length( ids );
+                    totalReads += seqan::length( ids );
                     queue1.push( ReadBatches{ ids, seqs } );
                 }
                 close( seqFileIn );
@@ -319,7 +323,7 @@ int main( int argc, char* argv[] )
 
             // bloom filter
             filterType filter;
-            retrieve( filter, toCString( bloom_filter_file_hierarchy ) );
+            retrieve( filter, seqan::toCString( bloom_filter_file_hierarchy ) );
             filter_hierarchy.push_back(
                 Filter{ std::move( filter ), group_bin, getNumberOfBins( filter ), getKmerSize( filter ) } );
         }
@@ -363,9 +367,9 @@ int main( int argc, char* argv[] )
                     if ( rb.ids != "" )
                     {                                // if not empty
                         ReadBatches left_over_reads; // store unclassified reads for next iteration
-                        for ( uint32_t readID = 0; readID < length( rb.ids ); ++readID )
+                        for ( uint32_t readID = 0; readID < seqan::length( rb.ids ); ++readID )
                         {
-                            uint16_t readLen = length( rb.seqs[readID] );
+                            uint16_t readLen = seqan::length( rb.seqs[readID] );
                             // count lens just once
                             if ( hierarchy_id == 1 )
                                 sumReadLen += readLen;
@@ -464,7 +468,7 @@ int main( int argc, char* argv[] )
                         }
 
                         // if something was added to the classified reads (there are more levels, keep reads in memory)
-                        if ( length( left_over_reads.ids ) > 0 )
+                        if ( seqan::length( left_over_reads.ids ) > 0 )
                             pointer_helper->push( left_over_reads );
                     }
 
@@ -473,8 +477,6 @@ int main( int argc, char* argv[] )
                                 ->empty() ) // if finished reading from file (first iter) and current queue is empty
                         break;
                 }
-
-
             } ) );
         }
         for ( auto&& task : tasks )

--- a/src/ganon-update/ganon-update.cpp
+++ b/src/ganon-update/ganon-update.cpp
@@ -12,16 +12,14 @@
 #include <mutex>
 #include <vector>
 
-using namespace seqan;
-
 static const uint32_t filterMetadataSize = 256;
 static const uint64_t gbInBits           = 8589934592;
 
 struct SeqBin
 {
-    CharString id;
-    Dna5String seq;
-    uint64_t   bin;
+    seqan::CharString id;
+    seqan::Dna5String seq;
+    uint64_t          bin;
 };
 
 int main( int argc, char* argv[] )
@@ -69,9 +67,10 @@ int main( int argc, char* argv[] )
 
     int threads = args["threads"].as< int >();
 
-    auto                                                     start = std::chrono::high_resolution_clock::now();
-    KmerFilter< Dna5, InterleavedBloomFilter, Uncompressed > filter;
-    retrieve( filter, toCString( args["bloom-filter"].as< std::string >() ) );
+    auto start = std::chrono::high_resolution_clock::now();
+
+    seqan::KmerFilter< seqan::Dna5, seqan::InterleavedBloomFilter, seqan::Uncompressed > filter;
+    retrieve( filter, seqan::toCString( args["bloom-filter"].as< std::string >() ) );
     uint64_t                        number_of_bins = getNumberOfBins( filter );
     uint64_t                        kmer_size      = getKmerSize( filter );
     std::chrono::duration< double > elapsed        = std::chrono::high_resolution_clock::now() - start;
@@ -113,7 +112,7 @@ int main( int argc, char* argv[] )
                 SeqBin val = q.pop();
                 if ( val.id != "" )
                 { // if not empty
-                    insertKmer( filter, val.seq, val.bin, 0 );
+                    seqan::insertKmer( filter, val.seq, val.bin, 0 );
                     mtx.lock();
                     std::cerr << val.id << " -> k-mers added to bin " << val.bin << std::endl;
                     mtx.unlock();
@@ -128,8 +127,8 @@ int main( int argc, char* argv[] )
     tasks.emplace_back( std::async( std::launch::async, [=, &bins, &q, &finished, &mtx] {
         for ( auto const& reference_fasta_file : args["references"].as< std::vector< std::string > >() )
         {
-            SeqFileIn seqFileIn;
-            if ( !open( seqFileIn, toCString( reference_fasta_file ) ) )
+            seqan::SeqFileIn seqFileIn;
+            if ( !open( seqFileIn, seqan::toCString( reference_fasta_file ) ) )
             {
                 std::cerr << "Unable to open " << reference_fasta_file << std::endl;
                 continue;
@@ -140,19 +139,19 @@ int main( int argc, char* argv[] )
                 {
                     ; // spin
                 }
-                StringSet< CharString >  ids;
-                StringSet< IupacString > seqs;
+                seqan::StringSet< seqan::CharString >  ids;
+                seqan::StringSet< seqan::IupacString > seqs;
                 readRecords( ids, seqs, seqFileIn, threads * 5 );
-                for ( uint16_t readID = 0; readID < length( ids ); ++readID )
+                for ( uint16_t readID = 0; readID < seqan::length( ids ); ++readID )
                 {
-                    if ( length( seqs[readID] ) < kmer_size )
+                    if ( seqan::length( seqs[readID] ) < kmer_size )
                     { // sequence too small
                         mtx.lock();
                         std::cerr << ids[readID] << " has sequence smaller than k-mer size" << std::endl;
                         mtx.unlock();
                         continue;
                     }
-                    std::string cid = toCString( ids[readID] );
+                    std::string cid = seqan::toCString( ids[readID] );
                     std::string acc = cid.substr( 0, cid.find( ' ' ) );
                     if ( bins.count( acc ) == 0 )
                     { // not defined on the bins
@@ -178,9 +177,9 @@ int main( int argc, char* argv[] )
 
     start = std::chrono::high_resolution_clock::now();
     if ( args.count( "output-file" ) )
-        store( filter, toCString( args["output-file"].as< std::string >() ) );
+        seqan::store( filter, seqan::toCString( args["output-file"].as< std::string >() ) );
     else
-        store( filter, toCString( args["bloom-filter"].as< std::string >() ) );
+        seqan::store( filter, seqan::toCString( args["bloom-filter"].as< std::string >() ) );
     elapsed = std::chrono::high_resolution_clock::now() - start;
     std::cerr << "Saving Bloom filter: " << elapsed.count() << std::endl;
 

--- a/src/ganon-update/ganon-update.cpp
+++ b/src/ganon-update/ganon-update.cpp
@@ -71,8 +71,8 @@ int main( int argc, char* argv[] )
 
     seqan::KmerFilter< seqan::Dna5, seqan::InterleavedBloomFilter, seqan::Uncompressed > filter;
     retrieve( filter, seqan::toCString( args["bloom-filter"].as< std::string >() ) );
-    uint64_t                        number_of_bins = getNumberOfBins( filter );
-    uint64_t                        kmer_size      = getKmerSize( filter );
+    uint64_t                        number_of_bins = seqan::getNumberOfBins( filter );
+    uint64_t                        kmer_size      = seqan::getKmerSize( filter );
     std::chrono::duration< double > elapsed        = std::chrono::high_resolution_clock::now() - start;
     std::cerr << "Loading Bloom filter: " << elapsed.count() << std::endl;
 
@@ -94,7 +94,7 @@ int main( int argc, char* argv[] )
     {
         std::vector< uint32_t > ubins;
         ubins.insert( ubins.end(), updated_bins.begin(), updated_bins.end() );
-        clear( filter, ubins, threads );
+        seqan::clear( filter, ubins, threads );
     }
 
     std::mutex                         mtx;
@@ -128,12 +128,12 @@ int main( int argc, char* argv[] )
         for ( auto const& reference_fasta_file : args["references"].as< std::vector< std::string > >() )
         {
             seqan::SeqFileIn seqFileIn;
-            if ( !open( seqFileIn, seqan::toCString( reference_fasta_file ) ) )
+            if ( !seqan::open( seqFileIn, seqan::toCString( reference_fasta_file ) ) )
             {
                 std::cerr << "Unable to open " << reference_fasta_file << std::endl;
                 continue;
             }
-            while ( !atEnd( seqFileIn ) )
+            while ( !seqan::atEnd( seqFileIn ) )
             {
                 while ( q.size() > ( threads * 10 ) )
                 {
@@ -141,7 +141,7 @@ int main( int argc, char* argv[] )
                 }
                 seqan::StringSet< seqan::CharString >  ids;
                 seqan::StringSet< seqan::IupacString > seqs;
-                readRecords( ids, seqs, seqFileIn, threads * 5 );
+                seqan::readRecords( ids, seqs, seqFileIn, threads * 5 );
                 for ( uint16_t readID = 0; readID < seqan::length( ids ); ++readID )
                 {
                     if ( seqan::length( seqs[readID] ) < kmer_size )
@@ -163,7 +163,7 @@ int main( int argc, char* argv[] )
                     q.push( SeqBin{ acc, seqs[readID], bins[acc] } );
                 }
             }
-            close( seqFileIn );
+            seqan::close( seqFileIn );
         }
         finished = true;
     } ) );


### PR DESCRIPTION
The goal here is to explicitly call `seqan` symbols using its namespace, for the sake of clarity.

**YET... SOMETHING CAME UP:** looks like some symbols are leaking out of the `seqan` namespace. For example, commit 3416ef0af19d33283b55b03b3494e3e63ab9f61e adds `seqan::` to fully qualify functions from the library, yet, that was not causing compiler errors (as can be seen in the previous commits).

@pirovc, can you please verify that we are getting the right calls and that these PR is not causing any change in performance?