### PR TITLE
Feature/refactor travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-trusty-6.0
           packages:
-            - g++-7 # for libstdc++ dependency
+            - libstdc++-6-dev
             - clang-6.0
       env:
         - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ matrix:
   include:
     - name: "linux gcc-7"
       os: linux
-      dist: trusty
       addons:
         apt: { packages: [g++-7],
                sources:  [ubuntu-toolchain-r-test] }
@@ -12,7 +11,6 @@ matrix:
 
     - name: "linux clang-6"
       os: linux
-      dist: trusty
       addons:
         apt: { packages: [clang-6.0, libstdc++-7-dev],
                sources:  [llvm-toolchain-trusty-6.0, ubuntu-toolchain-r-test] }

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,27 +6,17 @@ matrix:
       os: linux
       dist: trusty
       addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
-      env:
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+        apt: { packages: [g++-7],
+               sources:  [ubuntu-toolchain-r-test] }
+      env: MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
 
     - name: "linux clang-6"
       os: linux
       dist: trusty
       addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-6.0
-          packages:
-            - libstdc++-7-dev
-            - clang-6.0
-      env:
-        - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
+        apt: { packages: [clang-6.0, libstdc++-7-dev],
+               sources:  [llvm-toolchain-trusty-6.0, ubuntu-toolchain-r-test] }
+      env: MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
 
 before_install:
   - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ before_install:
 
 script:
   - mkdir build && cd build
-  - cmake -DCMAKE_BUILD_TYPE=Release -DVERBOSE_CONFIG=ON ..
+  - cmake -DCMAKE_BUILD_TYPE=Release -DVERBOSE_CONFIG=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+  - cat compile_commands.json
   - cmake --build .
   - ./ganon-build
   - ./ganon-classify

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
   - mkdir build && cd build
   - cmake -DCMAKE_BUILD_TYPE=Release -DVERBOSE_CONFIG=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
   - cat compile_commands.json
-  - cmake --build .
+  - cmake --build . -- -j2
   - ./ganon-build
   - ./ganon-classify
   - ./ganon-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-trusty-6.0
           packages:
-            - libstdc++-6-dev
+            - libstdc++-7-dev
             - clang-6.0
       env:
         - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"


### PR DESCRIPTION
Small refactoring on `.travis.yml`:

1. install package `libstdc++-7` instead of the whole `g++-7` for `clang-6` (this is the important part of the PR)
2. export compile commands and print them out (so compiler flags easy verification)
3. add `-j 2` to build command to speed up things a bit
4. remove dist as trusty is now the default dist in travis
5. style format