### PR TITLE
Bump cmake version to 3.8.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # ganon
 # ===========================================================================
 
-cmake_minimum_required( VERSION 3.2 FATAL_ERROR )
+cmake_minimum_required( VERSION 3.8.2 FATAL_ERROR )
 project( ganon LANGUAGES CXX )
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses issue #11:

Version 3.8.2 is the first version to offer C++17 for the `CXX_STANDARD 17` variable. See more here: https://cmake.org/cmake/help/v3.8/prop_tgt/CXX_STANDARD.html.

**Travis CI** has cmake 3.9.2, there so we are good.