### PR TITLE
Feature/fix seg fault on unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ script:
   - cat compile_commands.json
   - cmake --build . -- -j2
   - ctest -VV .
-  - ./ganon-build
-  - ./ganon-classify
 
 notifications:
   email: false

--- a/src/ganon-build/CommandLineParser.cpp
+++ b/src/ganon-build/CommandLineParser.cpp
@@ -4,6 +4,9 @@
 
 #include <cxxopts.hpp>
 
+namespace GanonBuild
+{
+
 std::optional< Config > CommandLineParser::parse( int argc, char** argv )
 {
     cxxopts::Options options( "ganon-build", "Ganon builder" );
@@ -75,3 +78,5 @@ std::optional< Config > CommandLineParser::parse( int argc, char** argv )
 
     return config;
 }
+
+} // namespace GanonBuild

--- a/src/ganon-build/GanonBuild.cpp
+++ b/src/ganon-build/GanonBuild.cpp
@@ -77,7 +77,7 @@ void parse_seqid_bin( const std::string& seqid_bin_file, TSeqBin& seq_bin, std::
 }
 
 
-TInterleavedBloomFilter load_filter( Config& config, const std::set< uint64_t >& bin_ids, Stats& stats )
+TInterleavedBloomFilter load_filter( GanonBuild::Config& config, const std::set< uint64_t >& bin_ids, Stats& stats )
 {
     uint64_t number_of_bins;
     if ( !config.update_filter_file.empty() )
@@ -118,12 +118,12 @@ TInterleavedBloomFilter load_filter( Config& config, const std::set< uint64_t >&
     return filter;
 }
 
-void print_time( const Config& config,
-                 Time&         timeGanon,
-                 Time&         timeLoadFiles,
-                 Time&         timeLoadSeq,
-                 Time&         timeBuild,
-                 Time&         timeSaveFilter )
+void print_time( const GanonBuild::Config& config,
+                 Time&                     timeGanon,
+                 Time&                     timeLoadFiles,
+                 Time&                     timeLoadSeq,
+                 Time&                     timeBuild,
+                 Time&                     timeSaveFilter )
 {
     std::cerr << "ganon-build       start time: " << timeGanon.get_start_ctime();
     std::cerr << "Loading files     start time: " << timeLoadFiles.get_start_ctime();
@@ -144,8 +144,7 @@ void print_time( const Config& config,
     std::cerr << std::endl;
 }
 
-
-void print_stats( Stats& stats, const Config& config, Time& timeBuild )
+void print_stats( Stats& stats, const GanonBuild::Config& config, Time& timeBuild )
 {
     double   elapsed_build = timeBuild.get_elapsed();
     uint64_t validSeqs     = stats.totalSeqsFile - stats.invalidSeqs;

--- a/src/ganon-build/include/ganon-build/CommandLineParser.hpp
+++ b/src/ganon-build/include/ganon-build/CommandLineParser.hpp
@@ -4,9 +4,9 @@
 
 #include <optional>
 
-namespace CommandLineParser
+namespace GanonBuild::CommandLineParser
 {
 
 std::optional< Config > parse( int argc, char** argv );
 
-} // namespace CommandLineParser
+} // namespace GanonBuild::CommandLineParser

--- a/src/ganon-build/include/ganon-build/Config.hpp
+++ b/src/ganon-build/include/ganon-build/Config.hpp
@@ -6,6 +6,9 @@
 #include <string>
 #include <vector>
 
+namespace GanonBuild
+{
+
 struct Config
 {
     static constexpr std::uint64_t MBinBits = 8388608;
@@ -57,3 +60,5 @@ inline std::ostream& operator<<( std::ostream& stream, const Config& config )
 
     return stream;
 }
+
+} // namespace GanonBuild

--- a/src/ganon-build/main.cpp
+++ b/src/ganon-build/main.cpp
@@ -6,7 +6,7 @@
 
 int main( int argc, char** argv )
 {
-    if ( auto config = CommandLineParser::parse( argc, argv ); config.has_value() )
+    if ( auto config = GanonBuild::CommandLineParser::parse( argc, argv ); config.has_value() )
     {
         return GanonBuild::run( std::move( config.value() ) ) ? EXIT_SUCCESS : EXIT_FAILURE;
     }

--- a/src/ganon-build/main.cpp
+++ b/src/ganon-build/main.cpp
@@ -11,5 +11,5 @@ int main( int argc, char** argv )
         return GanonBuild::run( std::move( config.value() ) ) ? EXIT_SUCCESS : EXIT_FAILURE;
     }
 
-    return EXIT_SUCCESS;
+    return EXIT_FAILURE;
 }

--- a/src/ganon-classify/CommandLineParser.cpp
+++ b/src/ganon-classify/CommandLineParser.cpp
@@ -4,6 +4,9 @@
 
 #include <cxxopts.hpp>
 
+namespace GanonClassify
+{
+
 std::optional< Config > CommandLineParser::parse( int argc, char** argv )
 {
     cxxopts::Options options( "ganon-classify", "Ganon classifier" );
@@ -59,3 +62,5 @@ std::optional< Config > CommandLineParser::parse( int argc, char** argv )
 
     return config;
 }
+
+} // namespace GanonClassify

--- a/src/ganon-classify/GanonClassify.cpp
+++ b/src/ganon-classify/GanonClassify.cpp
@@ -130,12 +130,12 @@ inline uint16_t classify_read( Tmatches&              matches,
     return maxKmerCountRead;
 }
 
-inline uint32_t filter_matches( ReadOut&  read_out,
-                                Tmatches& matches,
-                                uint16_t  kmerSize,
-                                uint16_t  readLen,
-                                uint16_t  maxKmerCountRead,
-                                Config&   config )
+inline uint32_t filter_matches( ReadOut&               read_out,
+                                Tmatches&              matches,
+                                uint16_t               kmerSize,
+                                uint16_t               readLen,
+                                uint16_t               maxKmerCountRead,
+                                GanonClassify::Config& config )
 {
     // get maximum possible number of error for this read
     // (-kmerSize+readLen-maxKmerCountRead+1)/kmerSize in a ceil formula (x + y - 1) / y
@@ -192,13 +192,13 @@ void load_filters( std::vector< Filter >&                                filter_
     }
 }
 
-void print_time( Config& config,
-                 Time&   timeGanon,
-                 Time&   timeLoadReads,
-                 Time&   timeLoadFilters,
-                 Time&   timeClass,
-                 Time&   timePrintClass,
-                 Time&   timePrintUnclass )
+void print_time( GanonClassify::Config& config,
+                 Time&                  timeGanon,
+                 Time&                  timeLoadReads,
+                 Time&                  timeLoadFilters,
+                 Time&                  timeClass,
+                 Time&                  timePrintClass,
+                 Time&                  timePrintUnclass )
 {
     std::cerr << "ganon-classify start time: " << timeGanon.get_start_ctime();
     std::cerr << "Loading reads  start time: " << timeLoadReads.get_start_ctime();
@@ -245,7 +245,7 @@ std::vector< std::string > split( const std::string& s, char delimiter )
     return tokens;
 }
 
-bool parse_hierarchy( Config& config )
+bool parse_hierarchy( GanonClassify::Config& config )
 {
 
     if ( config.filter_hierarchy.empty() )

--- a/src/ganon-classify/include/ganon-classify/CommandLineParser.hpp
+++ b/src/ganon-classify/include/ganon-classify/CommandLineParser.hpp
@@ -4,9 +4,9 @@
 
 #include <optional>
 
-namespace CommandLineParser
+namespace GanonClassify::CommandLineParser
 {
 
 std::optional< Config > parse( int argc, char** argv );
 
-} // namespace CommandLineParser
+} // namespace GanonClassify::CommandLineParser

--- a/src/ganon-classify/include/ganon-classify/Config.hpp
+++ b/src/ganon-classify/include/ganon-classify/Config.hpp
@@ -7,6 +7,9 @@
 #include <string>
 #include <vector>
 
+namespace GanonClassify
+{
+
 struct Config
 {
     std::string                                                                    output_file;
@@ -24,7 +27,7 @@ struct Config
     std::map< std::string, std::vector< std::tuple< std::string, std::string > > > filters;
     bool                                                                           verbose;
     bool                                                                           testing = false; // internal
-};
+}; // namespace GanonClassifystructConfig
 
 inline std::ostream& operator<<( std::ostream& stream, const Config& config )
 {
@@ -54,3 +57,5 @@ inline std::ostream& operator<<( std::ostream& stream, const Config& config )
 
     return stream;
 }
+
+} // namespace GanonClassify

--- a/src/ganon-classify/include/ganon-classify/Config.hpp
+++ b/src/ganon-classify/include/ganon-classify/Config.hpp
@@ -27,7 +27,7 @@ struct Config
     std::map< std::string, std::vector< std::tuple< std::string, std::string > > > filters;
     bool                                                                           verbose;
     bool                                                                           testing = false; // internal
-}; // namespace GanonClassifystructConfig
+};
 
 inline std::ostream& operator<<( std::ostream& stream, const Config& config )
 {

--- a/src/ganon-classify/main.cpp
+++ b/src/ganon-classify/main.cpp
@@ -6,7 +6,7 @@
 
 int main( int argc, char** argv )
 {
-    if ( auto config = CommandLineParser::parse( argc, argv ); config.has_value() )
+    if ( auto config = GanonClassify::CommandLineParser::parse( argc, argv ); config.has_value() )
     {
         return GanonClassify::run( std::move( config.value() ) ) ? EXIT_SUCCESS : EXIT_FAILURE;
     }

--- a/src/ganon-classify/main.cpp
+++ b/src/ganon-classify/main.cpp
@@ -11,5 +11,5 @@ int main( int argc, char** argv )
         return GanonClassify::run( std::move( config.value() ) ) ? EXIT_SUCCESS : EXIT_FAILURE;
     }
 
-    return EXIT_SUCCESS;
+    return EXIT_FAILURE;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,7 +26,7 @@ file(
 add_executable( ganon-tests
     aux/Aux.hpp
     setup/Catch2.setup.cpp
-    #ganon-build/GanonBuild.test.cpp
+    ganon-build/GanonBuild.test.cpp
     ganon-classify/GanonClassify.test.cpp
     utils/SafeQueue.test.cpp
     )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,34 +2,15 @@
 # ganon tests
 # ===========================================================================
 
-file(
-    COPY
-    ganon-build/data/bacteria_NC_010333.1.fasta.gz
-    ganon-build/data/bacteria_NC_017163.1.fasta.gz
-    ganon-build/data/bacteria_NC_017164.1.fasta.gz
-    ganon-build/data/bacteria_NC_017543.1.fasta.gz
-    ganon-build/data/bacteria_seqid_bin.txt
-    ganon-build/data/build_output.filter
-    DESTINATION
-    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} )
-
-file(
-    COPY
-    ganon-classify/data/bacteria_group_bin.txt
-    ganon-classify/data/classify.filter
-    ganon-classify/data/classify_output.txt
-    ganon-classify/data/simulated.1.fq
-    ganon-classify/data/simulated.2.fq
-    DESTINATION
-    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} )
+file( COPY ganon-build/data DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} )
+file( COPY ganon-classify/data DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} )
 
 add_executable( ganon-tests
     aux/Aux.hpp
     setup/Catch2.setup.cpp
     ganon-build/GanonBuild.test.cpp
     ganon-classify/GanonClassify.test.cpp
-    utils/SafeQueue.test.cpp
-    )
+    utils/SafeQueue.test.cpp )
 
 target_link_libraries( ganon-tests
     PRIVATE
@@ -42,4 +23,4 @@ target_include_directories( ganon-tests PRIVATE . )
 
 add_test( NAME GanonTestSuite
     COMMAND $<TARGET_FILE:ganon-tests>
-    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} )
+    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/data )

--- a/tests/ganon-build/GanonBuild.test.cpp
+++ b/tests/ganon-build/GanonBuild.test.cpp
@@ -8,9 +8,9 @@
 namespace config_build
 {
 
-Config testConfig()
+GanonBuild::Config testConfig()
 {
-    Config cfg;
+    GanonBuild::Config cfg;
     cfg.seqid_bin_file     = "bacteria_seqid_bin.txt";
     cfg.output_filter_file = "test_output.filter";
     cfg.filter_size        = 15797760;

--- a/tests/ganon-classify/GanonClassify.test.cpp
+++ b/tests/ganon-classify/GanonClassify.test.cpp
@@ -8,9 +8,9 @@
 namespace config_classify
 {
 
-Config testConfig()
+GanonClassify::Config testConfig()
 {
-    Config cfg;
+    GanonClassify::Config cfg;
     cfg.bloom_filter_files = { "classify.filter" };
     cfg.group_bin_files    = { "bacteria_group_bin.txt" };
     cfg.output_file        = "test_output.txt";


### PR DESCRIPTION
This PR fixes the problem we were having to run both ganon-classify and ganon-build on the same test executable binary. The problem was that the symbols from both ganon builds were getting mixed. Funny enough there was no compiler error, but the generated binary was wrong.