### PR TITLE
Add option taxsbp-path to ganon-classify

### DIFF
--- a/ganon
+++ b/ganon
@@ -83,6 +83,7 @@ def main():
     # Extra
     classify_group_optional.add_argument('--verbose',                           default=False, action='store_true',  help='Output in verbose mode for ganon-classify')
     classify_group_optional.add_argument('--ganon-path', type=str, default="./", help=argparse.SUPPRESS)
+    classify_group_optional.add_argument('--taxsbp-path', type=str, default="./", help=argparse.SUPPRESS)
     classify_group_optional.add_argument('--n-reads', type=int, help=argparse.SUPPRESS)
     classify_group_optional.add_argument('--n-batches', type=int, help=argparse.SUPPRESS)
 


### PR DESCRIPTION
In order to run `ganon --classify` withthout a global available taxsbp I had to include this option in the same way as for the build step