### PR TITLE
Feature/add gcc 8 to travis plan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ matrix:
       osx_image: xcode10
       env: MATRIX_EVAL="brew install gcc@7 && CC=gcc-7 && CXX=g++-7" BUILD_TYPE=Release
 
+    - name: "osx gcc-8"
+      os: osx
+      osx_image: xcode10
+      env: MATRIX_EVAL="brew install gcc@8 && CC=gcc-8 && CXX=g++-8" BUILD_TYPE=Release
+
     - name: "linux gcc-7"
       os: linux
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,13 @@ matrix:
                sources:  [ubuntu-toolchain-r-test] }
       env: MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" BUILD_TYPE=Release
 
+    - name: "linux gcc-8"
+      os: linux
+      addons:
+        apt: { packages: [g++-8],
+               sources:  [ubuntu-toolchain-r-test] }
+      env: MATRIX_EVAL="CC=gcc-8 && CXX=g++-8" BUILD_TYPE=Release
+
     - name: "linux gcc-7 (coverage)"
       os: linux
       addons:


### PR DESCRIPTION
Let's add now **gcc-8** to the build plan in order to guarantee a smooth transition into newer versions of the compiler (or event into c++20) in the future. In exchange, the plan will become, of course, a bit slower.

Since Travis has Ubuntu 16.04, we cannot unfortunately easily add clang version above 6 for the moment. But let's keep an eye on this...

ps.: minha fita do Raven quebrou!