### PR TITLE
Feature/fix travis build plan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,13 @@ matrix:
                sources:  [llvm-toolchain-trusty-6.0, ubuntu-toolchain-r-test] }
       env: MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0" BUILD_TYPE=Release
 
+    - name: "linux clang-7"
+      os: linux
+      addons:
+        apt: { packages: [clang-7.0, libstdc++-7-dev],
+               sources:  [llvm-toolchain-trusty-7.0, ubuntu-toolchain-r-test] }
+      env: MATRIX_EVAL="CC=clang-7.0 && CXX=clang++-7.0" BUILD_TYPE=Release
+
 before_install:
   - eval "${MATRIX_EVAL}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+dist: trusty
 
 matrix:
   include:
@@ -36,7 +37,7 @@ matrix:
     - name: "linux clang-6"
       os: linux
       addons:
-        apt: { packages: [clang-6.0, libjsoncpp-dev, libstdc++-7-dev],
+        apt: { packages: [clang-6.0, libstdc++-7-dev],
                sources:  [llvm-toolchain-trusty-6.0, ubuntu-toolchain-r-test] }
       env: MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0" BUILD_TYPE=Release
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
     - name: "linux clang-6"
       os: linux
       addons:
-        apt: { packages: [clang-6.0, libstdc++-7-dev],
+        apt: { packages: [clang-6.0, libjsoncpp-dev, libstdc++-7-dev],
                sources:  [llvm-toolchain-trusty-6.0, ubuntu-toolchain-r-test] }
       env: MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0" BUILD_TYPE=Release
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,6 @@ matrix:
                sources:  [llvm-toolchain-trusty-6.0, ubuntu-toolchain-r-test] }
       env: MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0" BUILD_TYPE=Release
 
-    - name: "linux clang-7"
-      os: linux
-      addons:
-        apt: { packages: [clang-7.0, libstdc++-7-dev],
-               sources:  [llvm-toolchain-trusty-7.0, ubuntu-toolchain-r-test] }
-      env: MATRIX_EVAL="CC=clang-7.0 && CXX=clang++-7.0" BUILD_TYPE=Release
-
 before_install:
   - eval "${MATRIX_EVAL}"
 


### PR DESCRIPTION
I am not sure why this is happening... but on the main repo, Travis is picking up Ubuntu Xenial, even though Trusty is the default distro for linux (here https://docs.travis-ci.com/user/reference/overview/).

Since we explicitly use sources for Trusty (`llvm-toolchain-trusty-6.0`), running this on Xenial was bringing the wrong packages. Check that the distro used here is Xenial: https://api.travis-ci.org/v3/job/526336600/log.txt