### PR TITLE
Update codecov script to target dev branch

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,5 @@
 codecov:
-  branch: master
+  branch: dev
 
 ignore:
   - "/usr/.*"


### PR DESCRIPTION
We must re-target the branch on codecov for `dev`, otherwise we will not get reports when PRs are targeting `dev`.

This should be merged before #76 .