### PR TITLE
Feature/refactor lca header coding style

### DIFF
--- a/src/utils/include/utils/LCA.hpp
+++ b/src/utils/include/utils/LCA.hpp
@@ -25,67 +25,67 @@ private:
     void preProcessRMQ();
     int  queryRMQ( int i, int j );
 
-    std::unordered_map< std::string, std::vector< std::string > > parents;
-    std::vector< int >                                            euler;
-    std::vector< int >                                            depth;
-    std::unique_ptr< int[] >                                      firstAppearance;
-    int                                                           vertices = 0;
-    std::unordered_map< std::string, int >                        encode;
-    std::unordered_map< int, std::string >                        decode;
-    std::unique_ptr< std::unique_ptr< int[] >[] >                 M;
+    std::unordered_map< std::string, std::vector< std::string > > m_parents;
+    std::vector< int >                                            m_euler;
+    std::vector< int >                                            m_depth;
+    std::unique_ptr< int[] >                                      m_firstAppearance;
+    int                                                           m_vertices = 0;
+    std::unordered_map< std::string, int >                        m_encode;
+    std::unordered_map< int, std::string >                        m_decode;
+    std::unique_ptr< std::unique_ptr< int[] >[] >                 m_M;
 };
 
 inline void LCA::addEdge( std::string father, std::string son )
 {
-    if ( encode.count( father ) == 0 )
+    if ( m_encode.count( father ) == 0 )
     {
-        encode.insert( { father, vertices } );
-        decode.insert( { vertices, father } );
-        vertices++;
+        m_encode.insert( { father, m_vertices } );
+        m_decode.insert( { m_vertices, father } );
+        m_vertices++;
     }
-    if ( encode.count( son ) == 0 )
+    if ( m_encode.count( son ) == 0 )
     {
-        encode.insert( { son, vertices } );
-        decode.insert( { vertices, son } );
-        vertices++;
+        m_encode.insert( { son, m_vertices } );
+        m_decode.insert( { m_vertices, son } );
+        m_vertices++;
     }
-    if ( parents.count( father ) == 0 )
+    if ( m_parents.count( father ) == 0 )
     {
         std::vector< std::string > children;
         children.push_back( son );
-        parents[father] = children;
+        m_parents[father] = children;
     }
     else
     {
-        parents[father].push_back( son );
+        m_parents[father].push_back( son );
     }
 }
 
-inline void LCA::depthFirstSearch( std::string current, int _depth )
+inline void LCA::depthFirstSearch( std::string current, int depth )
 {
     // marking first appearance for current node
-    if ( firstAppearance[encode[current]] == -1 )
+    if ( m_firstAppearance[m_encode[current]] == -1 )
     {
-        firstAppearance[encode[current]] = euler.size();
+        m_firstAppearance[m_encode[current]] = m_euler.size();
     }
     // pushing root to euler walk
-    euler.push_back( encode[current] );
+    m_euler.push_back( m_encode[current] );
     // pushing depth of current node
-    this->depth.push_back( _depth );
-    for ( unsigned int i = 0; i < parents[current].size(); i++ )
+    m_depth.push_back( depth );
+    for ( unsigned int i = 0; i < m_parents[current].size(); i++ )
     {
-        depthFirstSearch( parents[current][i], _depth + 1 );
-        euler.push_back( encode[current] );
-        this->depth.push_back( _depth );
+        depthFirstSearch( m_parents[current][i], depth + 1 );
+        m_euler.push_back( m_encode[current] );
+        m_depth.push_back( depth );
     }
 }
 
 inline void LCA::doEulerWalk()
 {
-    firstAppearance = std::make_unique< int[] >( vertices );
-    for ( int i = 0; i < vertices; i++ )
+    m_firstAppearance = std::make_unique< int[] >( m_vertices );
+    for ( int i = 0; i < m_vertices; i++ )
     {
-        firstAppearance[i] = -1;
+        m_firstAppearance[i] = -1;
     }
     depthFirstSearch( "1", 0 );
     preProcessRMQ();
@@ -95,28 +95,28 @@ inline void LCA::doEulerWalk()
 inline void LCA::preProcessRMQ()
 {
 
-    M = std::make_unique< std::unique_ptr< int[] >[] >( depth.size() );
+    m_M = std::make_unique< std::unique_ptr< int[] >[] >( m_depth.size() );
 
-    int logDepth = std::ceil( std::log2( depth.size() ) );
-    for ( unsigned int i = 0; i < depth.size(); i++ )
+    int logDepth = std::ceil( std::log2( m_depth.size() ) );
+    for ( unsigned int i = 0; i < m_depth.size(); i++ )
     {
-        M[i]    = std::make_unique< int[] >( logDepth );
-        M[i][0] = i; // initialize M for the intervals with length 1
+        m_M[i]    = std::make_unique< int[] >( logDepth );
+        m_M[i][0] = i; // initialize M for the intervals with length 1
     }
 
 
     // compute values from smaller to bigger intervals
-    for ( unsigned int j = 1; 1u << j <= depth.size(); j++ )
+    for ( unsigned int j = 1; 1u << j <= m_depth.size(); j++ )
     {
-        for ( unsigned int i = 0; i + ( 1 << j ) - 1 < depth.size(); i++ )
+        for ( unsigned int i = 0; i + ( 1 << j ) - 1 < m_depth.size(); i++ )
         {
-            if ( depth[M[i][j - 1]] < depth[M[i + ( 1 << ( j - 1 ) )][j - 1]] )
+            if ( m_depth[m_M[i][j - 1]] < m_depth[m_M[i + ( 1 << ( j - 1 ) )][j - 1]] )
             {
-                M[i][j] = M[i][j - 1];
+                m_M[i][j] = m_M[i][j - 1];
             }
             else
             {
-                M[i][j] = M[i + ( 1 << ( j - 1 ) )][j - 1];
+                m_M[i][j] = m_M[i + ( 1 << ( j - 1 ) )][j - 1];
             }
         }
     }
@@ -131,13 +131,13 @@ inline int LCA::queryRMQ( int i, int j )
 
     int k = std::log2( j - i + 1 );
 
-    if ( depth[M[i][k]] <= depth[M[j - ( 1 << k ) + 1][k]] )
+    if ( m_depth[m_M[i][k]] <= m_depth[m_M[j - ( 1 << k ) + 1][k]] )
     {
-        return M[i][k];
+        return m_M[i][k];
     }
     else
     {
-        return M[j - ( 1 << k ) + 1][k];
+        return m_M[j - ( 1 << k ) + 1][k];
     }
 }
 
@@ -155,22 +155,22 @@ inline int LCA::getLCA( int u, int v )
         return 0;
     }
 
-    if ( firstAppearance[u] > firstAppearance[v] )
+    if ( m_firstAppearance[u] > m_firstAppearance[v] )
     {
         std::swap( u, v );
     }
 
     // doing RMQ in the required range
-    return euler[queryRMQ( firstAppearance[u], firstAppearance[v] )];
+    return m_euler[queryRMQ( m_firstAppearance[u], m_firstAppearance[v] )];
 }
 
 inline std::string LCA::getLCA( std::vector< std::string >& taxIds )
 {
     int lca;
-    lca = getLCA( encode[taxIds[0]], encode[taxIds[1]] );
+    lca = getLCA( m_encode[taxIds[0]], m_encode[taxIds[1]] );
     for ( unsigned int i = 2; i < taxIds.size(); i++ )
     {
-        lca = getLCA( lca, encode[taxIds[i]] );
+        lca = getLCA( lca, m_encode[taxIds[i]] );
     }
-    return decode[lca];
+    return m_decode[lca];
 }

--- a/src/utils/include/utils/LCA.hpp
+++ b/src/utils/include/utils/LCA.hpp
@@ -9,30 +9,28 @@
 #include <unordered_map>
 #include <vector>
 
-using namespace std;
-
 // required: root node == "1" and father == "0"
 class LCA
 {
 private:
-    unordered_map< string, vector< string > > parents;
-    vector< int >                             euler;
-    vector< int >                             depth;
-    unique_ptr< int[] >                       firstAppearance;
-    int                                       vertices;
-    unordered_map< string, int >              encode;
-    unordered_map< int, string >              decode;
-    unique_ptr< unique_ptr< int[] >[] >       M;
-    void                                      depthFirstSearch( string current, int depth );
-    void                                      preProcessRMQ();
-    int                                       queryRMQ( int i, int j );
+    std::unordered_map< std::string, std::vector< std::string > > parents;
+    std::vector< int >                                            euler;
+    std::vector< int >                                            depth;
+    std::unique_ptr< int[] >                                      firstAppearance;
+    int                                                           vertices;
+    std::unordered_map< std::string, int >                        encode;
+    std::unordered_map< int, std::string >                        decode;
+    std::unique_ptr< std::unique_ptr< int[] >[] >                 M;
+    void                                                          depthFirstSearch( std::string current, int depth );
+    void                                                          preProcessRMQ();
+    int                                                           queryRMQ( int i, int j );
 
 public:
     LCA();
-    void   addEdge( string father, string son );
-    void   doEulerWalk();
-    int    getLCA( int u, int v );
-    string getLCA( vector< string >& taxIds );
+    void        addEdge( std::string father, std::string son );
+    void        doEulerWalk();
+    int         getLCA( int u, int v );
+    std::string getLCA( std::vector< std::string >& taxIds );
 };
 
 inline LCA::LCA()
@@ -40,7 +38,7 @@ inline LCA::LCA()
     vertices = 0;
 }
 
-inline void LCA::addEdge( string father, string son )
+inline void LCA::addEdge( std::string father, std::string son )
 {
     if ( encode.count( father ) == 0 )
     {
@@ -56,7 +54,7 @@ inline void LCA::addEdge( string father, string son )
     }
     if ( parents.count( father ) == 0 )
     {
-        vector< string > children;
+        std::vector< std::string > children;
         children.push_back( son );
         parents[father] = children;
     }
@@ -66,7 +64,7 @@ inline void LCA::addEdge( string father, string son )
     }
 }
 
-inline void LCA::depthFirstSearch( string current, int _depth )
+inline void LCA::depthFirstSearch( std::string current, int _depth )
 {
     // marking first appearance for current node
     if ( firstAppearance[encode[current]] == -1 )
@@ -87,7 +85,7 @@ inline void LCA::depthFirstSearch( string current, int _depth )
 
 inline void LCA::doEulerWalk()
 {
-    firstAppearance = make_unique< int[] >( vertices );
+    firstAppearance = std::make_unique< int[] >( vertices );
     for ( int i = 0; i < vertices; i++ )
     {
         firstAppearance[i] = -1;
@@ -100,12 +98,12 @@ inline void LCA::doEulerWalk()
 inline void LCA::preProcessRMQ()
 {
 
-    M = make_unique< unique_ptr< int[] >[] >( depth.size() );
+    M = std::make_unique< std::unique_ptr< int[] >[] >( depth.size() );
 
     int logDepth = ceil( log2( depth.size() ) );
     for ( unsigned int i = 0; i < depth.size(); i++ )
     {
-        M[i]    = make_unique< int[] >( logDepth );
+        M[i]    = std::make_unique< int[] >( logDepth );
         M[i][0] = i; // initialize M for the intervals with length 1
     }
 
@@ -131,7 +129,7 @@ inline int LCA::queryRMQ( int i, int j )
 {
     if ( i > j )
     {
-        swap( i, j );
+        std::swap( i, j );
     }
 
     int k = log2( j - i + 1 );
@@ -162,14 +160,14 @@ inline int LCA::getLCA( int u, int v )
 
     if ( firstAppearance[u] > firstAppearance[v] )
     {
-        swap( u, v );
+        std::swap( u, v );
     }
 
     // doing RMQ in the required range
     return euler[queryRMQ( firstAppearance[u], firstAppearance[v] )];
 }
 
-inline string LCA::getLCA( vector< string >& taxIds )
+inline std::string LCA::getLCA( std::vector< std::string >& taxIds )
 {
     int lca;
     lca = getLCA( encode[taxIds[0]], encode[taxIds[1]] );

--- a/src/utils/include/utils/LCA.hpp
+++ b/src/utils/include/utils/LCA.hpp
@@ -13,7 +13,8 @@
 class LCA
 {
 public:
-    LCA();
+    LCA() = default;
+
     void        addEdge( std::string father, std::string son );
     void        doEulerWalk();
     int         getLCA( int u, int v );
@@ -28,16 +29,11 @@ private:
     std::vector< int >                                            euler;
     std::vector< int >                                            depth;
     std::unique_ptr< int[] >                                      firstAppearance;
-    int                                                           vertices;
+    int                                                           vertices = 0;
     std::unordered_map< std::string, int >                        encode;
     std::unordered_map< int, std::string >                        decode;
     std::unique_ptr< std::unique_ptr< int[] >[] >                 M;
 };
-
-inline LCA::LCA()
-{
-    vertices = 0;
-}
 
 inline void LCA::addEdge( std::string father, std::string son )
 {

--- a/src/utils/include/utils/LCA.hpp
+++ b/src/utils/include/utils/LCA.hpp
@@ -12,7 +12,18 @@
 // required: root node == "1" and father == "0"
 class LCA
 {
+public:
+    LCA();
+    void        addEdge( std::string father, std::string son );
+    void        doEulerWalk();
+    int         getLCA( int u, int v );
+    std::string getLCA( std::vector< std::string >& taxIds );
+
 private:
+    void depthFirstSearch( std::string current, int depth );
+    void preProcessRMQ();
+    int  queryRMQ( int i, int j );
+
     std::unordered_map< std::string, std::vector< std::string > > parents;
     std::vector< int >                                            euler;
     std::vector< int >                                            depth;
@@ -21,16 +32,6 @@ private:
     std::unordered_map< std::string, int >                        encode;
     std::unordered_map< int, std::string >                        decode;
     std::unique_ptr< std::unique_ptr< int[] >[] >                 M;
-    void                                                          depthFirstSearch( std::string current, int depth );
-    void                                                          preProcessRMQ();
-    int                                                           queryRMQ( int i, int j );
-
-public:
-    LCA();
-    void        addEdge( std::string father, std::string son );
-    void        doEulerWalk();
-    int         getLCA( int u, int v );
-    std::string getLCA( std::vector< std::string >& taxIds );
 };
 
 inline LCA::LCA()

--- a/src/utils/include/utils/LCA.hpp
+++ b/src/utils/include/utils/LCA.hpp
@@ -97,7 +97,7 @@ inline void LCA::preProcessRMQ()
 
     M = std::make_unique< std::unique_ptr< int[] >[] >( depth.size() );
 
-    int logDepth = ceil( log2( depth.size() ) );
+    int logDepth = std::ceil( std::log2( depth.size() ) );
     for ( unsigned int i = 0; i < depth.size(); i++ )
     {
         M[i]    = std::make_unique< int[] >( logDepth );
@@ -129,7 +129,7 @@ inline int LCA::queryRMQ( int i, int j )
         std::swap( i, j );
     }
 
-    int k = log2( j - i + 1 );
+    int k = std::log2( j - i + 1 );
 
     if ( depth[M[i][k]] <= depth[M[j - ( 1 << k ) + 1][k]] )
     {


### PR DESCRIPTION
There are **no functional changes** whatsoever in this PR, it's purely cosmetic. This is part 1 of a two-part small effort to refactor `LCA.hpp`. Small points regarding this PR:

- remove `using namespace std`: it is not encouraged to do `using namespace` of any kind in a header file, as it bleeds the namespace scope into the scope of whoever includes the header;

- move `private` members to the bottom of the class definition: this is just a bit more C++ idiomatic, but the idea is that clients of a class should yield the public part and be totally unaware of the private implementation. Let's then present the public part first, at the top of the class;

- the calls to `<cmath>` are qualified with `std::`: if we include `<cmath>` (and not `<math.h>`), let's call the interface provided by C++ and not pure C;

- use prefix `m_` for member variables: this is a coding standard we already see in other classes of `ganon`. The good thing about this is that it becomes pretty clear what is private and we avoid name clashes (we had calls like `this->depth` and parameters names `_depth`).

Stern me up! :beer: