### PR TITLE
Feature/report not root

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ Obs:
 
 - Using `--report-type reads` the first line of the file will show the number of unclassified reads
 
-- When `--report-type reads` only taxa that received direct read matches, either unique or through lca, are considered. In cases where the classification is very ambiguous, some reads may have only shared matches and will not be reported. To look at those matches you can create a report with `--report-type matches` or look at the file {prefix}**.rep**.
+- When `--report-type reads` only taxa that received direct read matches, either unique or through lca, are considered. Some reads may have only shared matches and will not be reported. To look at those matches you can create a report with `--report-type matches` or look at the file {prefix}**.rep**.
+
 
 ### table
 
@@ -349,8 +350,7 @@ By default, `ganon classify` and  `ganon report` generate a read-based report (`
 
 #### --split-hierarchy, --keep-hierarchy or --skip-hierarchy
 
-When using multiple databases in different hierarchical levels to classify reads, it is possible to report them separetly using `--split-hierarchy`. Once activated, one report will be generated for each hierarchical label. In each hierarchical specific report, the counts of other hierarchies are going to be reported at the root level to keep consistency in the reports.
-It is also possible to select or ignore specific hierarchical labels (e.g. for a label use for host removal) using `--keep-hierarchy` or `--skip-hierarchy`.
+When using multiple databases in different hierarchical levels to classify reads, it is possible to report them separetly using `--split-hierarchy`. Once activated, one report will be generated for each hierarchical label. It is also possible to select or ignore specific hierarchical labels (e.g. for a label use for host removal) using `--keep-hierarchy` or `--skip-hierarchy`.
 
 ## Install without conda
 

--- a/README.md
+++ b/README.md
@@ -186,14 +186,15 @@ Obs:
 	3) target lineage *(e.g 1|2|1224|...)*
 	4) target name *(e.g. Paenibacillus polymyxa)*
 	5) \# unique assignments *(number of reads that matched exclusively to this target)*
-	6) \# reads/matches assignments *(number of reads/matches directly assigned to this target. Besides unique assignments, this number also includes lca assignments (in case of `--report-type reads`) or shared assignments (in case of `--report-type matches`))*
+	6) \# assignments *(number of reads or matches directly assigned to this target. This includes the number of unique assignments plus lca assignments (in case of `--report-type reads`) or shared assignments (in case of `--report-type matches`))*
 	7) \# cumulative assignments *(cumulative number of reads/matches assigned up-to this taxa)*
 	8) \% cumulative assignments
 
 - Using `--report-type reads` the first line of the file will show the number of unclassified reads
 
-- When `--report-type reads` only taxa that received direct read matches, either unique or through lca, are considered. Some reads may have only shared matches and will not be reported. To look at those matches you can create a report with `--report-type matches` or look at the file {prefix}**.rep**.
+- The sum of cumulative assignments for the unclassified and root lines should be 100%. The final cumulative sum of reads/matches may be under 100% if any filter is suceffully applied and/or hiearchical selection is selected (keep/skip/split).
 
+- When `--report-type reads` only taxa that received direct read matches, either unique or through lca, are considered. Some reads may have only shared matches and will not be reported. To look at those matches you can create a report with `--report-type matches` or look at the file {prefix}**.rep**.
 
 ### table
 

--- a/src/ganon/report.py
+++ b/src/ganon/report.py
@@ -39,15 +39,11 @@ def report(cfg):
             print_log(" - nothing to report for " + rep_file, cfg.quiet)
             continue
 
-        # If skipping/keeping hiearchies, remove all assignments from reports and count all to root
+        # If skipping/keeping hiearchies, remove all assignments from reports
         if cfg.skip_hierarchy or cfg.keep_hierarchy:
-            reports = count_hierarchy(reports, counts, cfg.skip_hierarchy, cfg.keep_hierarchy, cfg.quiet)
+            reports = remove_hierarchy(reports, counts, cfg.skip_hierarchy, cfg.keep_hierarchy, cfg.quiet)
 
-        # If splitting output, root from other hiearchies should be accounted for all files
-        #if cfg.split_hierarchy:
-        #    reports = split_hierarchy(reports, counts)
-
-                # General output file
+        # General output file
         if len(rep_files) == 1:
             output_file = cfg.output_prefix
         else:
@@ -317,41 +313,12 @@ def sort_report(filtered_cum_counts, sort, all_ranks, fixed_ranks, lineage, tax,
 
     return sorted_nodes
 
-def count_hierarchy(reports, counts, skip, keep, quiet):
-    hierarchy_reports = {}
+def remove_hierarchy(reports, counts, skip, keep, quiet):
     # In case of skipped hiearchy, account all matches to root node
-    if skip or keep:
-        for hierarchy_name in reports:
-            # Skiped report
-            if hierarchy_name in skip or (keep and hierarchy_name not in keep):
-                # set default root node and sum all counts to it
-                hierarchy_reports[hierarchy_name] = {"1": {"direct_matches": counts[hierarchy_name]["matches"], 
-                                                           "unique_reads": 0, 
-                                                           "lca_reads": counts[hierarchy_name]["reads"]}}
-                print_log(" - skipped " + str(counts[hierarchy_name]["reads"])  + " reads with " + str(counts[hierarchy_name]["matches"]) + " matches for " + hierarchy_name + " (counts assigned to root node)", quiet)
-            else:
-                hierarchy_reports[hierarchy_name] = reports[hierarchy_name]
-
-    return hierarchy_reports
-
-def split_hierarchy(reports, counts):
-    # In case of splitted reports, all hierarchies have to share the same root
-    # so all reports sum up to 100%
-    for hierarchy_reports, rep in reports.items():
-        # start counters with current assignments for root node in the hierarchy (if exists)
-        matches=rep["1"]["direct_matches"] if "1" in rep else 0
-        reads=rep["1"]["lca_reads"]+rep["1"]["unique_reads"] if "1" in rep else 0
-        for hierarchy_counts in counts:
-            if hierarchy_counts in ["total", hierarchy_reports]:
-                continue
-            else:
-                # Sum up counts from other hiearchies
-                matches+=counts[hierarchy_counts]["matches"]
-                reads+=counts[hierarchy_counts]["reads"]
-
-        # Set count to root of current hierarchy
-        rep["1"] = {"direct_matches": matches, 
-                    "unique_reads": 0, 
-                    "lca_reads": reads}
+    for hierarchy_name in list(reports.keys()):
+        # Skiped report
+        if hierarchy_name in skip or (keep and hierarchy_name not in keep):
+            del reports[hierarchy_name]
+            print_log(" - skipped " + str(counts[hierarchy_name]["reads"])  + " reads with " + str(counts[hierarchy_name]["matches"]) + " matches for " + hierarchy_name, quiet)
 
     return reports

--- a/src/ganon/report.py
+++ b/src/ganon/report.py
@@ -44,8 +44,8 @@ def report(cfg):
             reports = count_hierarchy(reports, counts, cfg.skip_hierarchy, cfg.keep_hierarchy, cfg.quiet)
 
         # If splitting output, root from other hiearchies should be accounted for all files
-        if cfg.split_hierarchy:
-            reports = split_hierarchy(reports, counts)
+        #if cfg.split_hierarchy:
+        #    reports = split_hierarchy(reports, counts)
 
                 # General output file
         if len(rep_files) == 1:

--- a/tests/ganon/integration/test_report.py
+++ b/tests/ganon/integration/test_report.py
@@ -161,7 +161,7 @@ class TestReportOffline(unittest.TestCase):
         # Run
         self.assertTrue(ganon.main(cfg=cfg), "ganon report exited with an error")
         # General sanity check of results
-        res = report_sanity_check_and_parse(vars(cfg))
+        res = report_sanity_check_and_parse(vars(cfg), sum_full_percentage=False)
         self.assertIsNotNone(res, "ganon report has inconsistent results")
         # should not have any assembly reported
         self.assertFalse((res["tre_pd"][~res["idx_base"]]["rank"].isin(["assembly"])).any(),"ganon report did not skip the hierarchy")
@@ -179,7 +179,7 @@ class TestReportOffline(unittest.TestCase):
         # Run
         self.assertTrue(ganon.main(cfg=cfg), "ganon report exited with an error")
         # General sanity check of results
-        res = report_sanity_check_and_parse(vars(cfg))
+        res = report_sanity_check_and_parse(vars(cfg), sum_full_percentage=False)
         self.assertIsNotNone(res, "ganon report has inconsistent results")
         # should not have any assembly reported
         self.assertFalse((res["tre_pd"][~res["idx_base"]]["rank"].isin(["assembly"])).any(),"ganon report did not skip the hierarchy")
@@ -198,16 +198,17 @@ class TestReportOffline(unittest.TestCase):
         # Run
         self.assertTrue(ganon.main(cfg=cfg), "ganon report exited with an error")
         # General sanity check of results
-        res = report_sanity_check_and_parse(vars(cfg))
+        res = report_sanity_check_and_parse(vars(cfg), sum_full_percentage=False)
         self.assertIsNotNone(res, "ganon report has inconsistent results")
         
+        # sum all root value
         total_root_split = 0
         for file,r in res.items():
-            total_root_cum = r["tre_pd"][r["tre_pd"]['rank'] == "root"]["cumulative"].values[0]
-            total_root_split+=r["tre_pd"][r["tre_pd"]['rank'] == "root"]["total"].values[0]
-
-        # values reported on root of splitted reports should equal total
-        self.assertEqual(total_root_split/(len(res)-1), total_root_cum, "ganon report with wrong root counts")
+            total_root_split+=r["tre_pd"][r["tre_pd"]['rank'] == "root"]["cumulative_perc"].values[0]
+        # sum one time unclassified
+        total_root_split+=r["tre_pd"][r["tre_pd"]['rank'] == "unclassified"]["cumulative_perc"].values[0]
+        # values reported on root of splitted reports should equal 100
+        self.assertEqual(int(total_root_split), 100, "ganon report with wrong root counts")
 
     def test_multiple_rep_files(self):
         """
@@ -241,7 +242,7 @@ class TestReportOffline(unittest.TestCase):
         # Run
         self.assertTrue(ganon.main(cfg=cfg), "ganon report exited with an error")
         # General sanity check of results
-        res = report_sanity_check_and_parse(vars(cfg))
+        res = report_sanity_check_and_parse(vars(cfg), sum_full_percentage=False)
         self.assertIsNotNone(res, "ganon report has inconsistent results")
         
         # should have 2+4 outputs (6 hiearchies)

--- a/tests/ganon/utils.py
+++ b/tests/ganon/utils.py
@@ -113,7 +113,7 @@ def classify_sanity_check_and_parse(params):
     res["lca_pd"] = parse_all_lca(params["output_prefix"]+".lca")
     return res
 
-def report_sanity_check_and_parse(params):
+def report_sanity_check_and_parse(params, sum_full_percentage: bool=True):
     
     # get all output files referent to the run by name
     output_files = []
@@ -140,7 +140,7 @@ def report_sanity_check_and_parse(params):
             res["idx_base"] = res["idx_root"]
         
         # Check if total is 100%
-        if floor(res["tre_pd"][res["idx_base"]]["cumulative_perc"].sum())!=100:
+        if sum_full_percentage and floor(res["tre_pd"][res["idx_base"]]["cumulative_perc"].sum())!=100:
             print("Inconsistent total percentage")
             return None
 


### PR DESCRIPTION
Undo some addition from #157 
Reports do not have to sum up to 100% in case of any filtration or hierarchical keep/skip/split