### PR TITLE
Feature/write stats file

### DIFF
--- a/docs/params.md
+++ b/docs/params.md
@@ -247,7 +247,8 @@ optional arguments:
 usage: ganon classify [-h] -d [DB_PREFIX ...] -o OUTPUT_PREFIX [-s [reads.fq[.gz] ...]]
                       [-p [reads.1.fq[.gz] reads.2.fq[.gz] ...]] [-a [file.tsv ...]] [-c [ ...]] [-e [ ...]] [-m ]
                       [--ranks [ ...]] [--min-count ] [--report-type ] [--skip-report] [--output-one] [--output-all]
-                      [--output-unclassified] [--output-single] [-t ] [-b] [-f [ ...]] [-l [ ...]] [--verbose] [--quiet]
+                      [--output-unclassified] [--output-stats] [--output-single] [-t ] [-b] [-f [ ...]] [-l [ ...]]
+                      [--verbose] [--quiet]
 
 options:
   -h, --help            show this help message and exit
@@ -296,6 +297,7 @@ output arguments:
   --output-all          Output a file with all unique and multiple matches (.all) (default: False)
   --output-unclassified
                         Output a file with unclassified read headers (.unc) (default: False)
+  --output-stats        Output a file with statistic of classification (.sta) (default: False)
   --output-single       When using multiple hierarchical levels, output everything in one file instead of one per
                         hierarchy (default: False)
 

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
+echo "---- ruff format/check ----"
 ruff format
 ruff check --fix
 
 # C++
-find src/ -iname '*.hpp' -o -iname '*.cpp' | xargs clang-format -i
-find tests/ -iname '*.hpp' -o -iname '*.cpp' | xargs clang-format -i
+echo "---- clang-format ----"
+find {src/,tests/} -iname '*.hpp' -o -iname '*.cpp' | xargs clang-format --verbose -i
 
 # Update docs
+echo "---- update docs ----"
 docs/generate_params.sh > docs/params.md
 v=$(ganon --version | cut -d" " -f 3)
 sed -i 's/'$v'/'${v:0:5}'/' docs/params.md
+
+# Tests
+echo "---- tests c++ ----"
+ctest --test-dir build/
+echo "---- tests python ----"
+python3 -m unittest discover -s tests/ganon/integration/

--- a/src/ganon-classify/CommandLineParser.cpp
+++ b/src/ganon-classify/CommandLineParser.cpp
@@ -30,7 +30,8 @@ std::optional< Config > CommandLineParser::parse( int argc, char** argv )
         ( "l,output-lca", "Runs and outputs file with lca classification (prefix.one)", cxxopts::value< bool >() )
         ( "a,output-all", "Outputs file with all matches (prefix.all)", cxxopts::value< bool >() )
         ( "u,output-unclassified", "Outputs unclassified read ids (prefix.unc)", cxxopts::value< bool >() )
-        ( "s,output-single", "Do not split output files (lca and all) with multi-level --hierarchy-labels", cxxopts::value< bool >() )
+        ( "z,output-stats", "Outputs classification statistics (prefix.sta)", cxxopts::value< bool >() )
+        ( "s,output-single", "Do not split output files (one and all) with multi-level --hierarchy-labels", cxxopts::value< bool >() )
         
         ( "hibf", "Input is an Hierarchical IBF (.hibf) generated from raptor.", cxxopts::value< bool >())
         ( "skip-lca", "Skip LCA step.", cxxopts::value< bool >())
@@ -95,6 +96,8 @@ std::optional< Config > CommandLineParser::parse( int argc, char** argv )
         config.output_all = args["output-all"].as< bool >();
     if ( args.count( "output-unclassified" ) )
         config.output_unclassified = args["output-unclassified"].as< bool >();
+    if ( args.count( "output-stats" ) )
+        config.output_stats = args["output-stats"].as< bool >();
     if ( args.count( "output-single" ) )
         config.output_single = args["output-single"].as< bool >();
 

--- a/src/ganon-classify/GanonClassify.cpp
+++ b/src/ganon-classify/GanonClassify.cpp
@@ -1183,8 +1183,8 @@ void write_stats( std::string                                     output_prefix,
         out_sta << "seq_unique_matches_perc" << '\t';
         out_sta << "seq_multiple_matches" << '\t';
         out_sta << "seq_multiple_matches_perc" << '\t';
-        out_sta << "total_seq_matches" << '\t';
-        out_sta << "avg_matches_per_seq" << '\t';
+        out_sta << "matches" << '\t';
+        out_sta << "avg_matches_ref_seq" << '\t';
         out_sta << "dis_matches_rel_filter" << '\t';
         out_sta << "dis_matches_fpr_query" << '\t';
         out_sta << "kmers_proccessed" << '\t';

--- a/src/ganon-classify/GanonClassify.cpp
+++ b/src/ganon-classify/GanonClassify.cpp
@@ -459,6 +459,8 @@ void print_output_files( const Config&                                   config,
         std::cerr << config.output_prefix + prefix + ".rep" << newl;
         if ( config.output_unclassified )
             std::cerr << config.output_prefix + prefix + ".unc" << newl;
+        if ( config.output_stats )
+            std::cerr << config.output_prefix + prefix + ".sta" << newl;
         for ( auto& [hierarchy_label, hierarchy_config] : parsed_hierarchy )
         {
             if ( config.output_lca )
@@ -1125,6 +1127,93 @@ void print_stats( Stats&                                          stats,
     }
 }
 
+void write_stats_db( const Total&   total,
+                     double         seq_processed,
+                     size_t         seq_unclassified,
+                     size_t         kmers_processed,
+                     std::string    prefix,
+                     std::string    hierarchy_level,
+                     std::ofstream& out_sta )
+{
+
+    const size_t seq_multiple_matches = total.seqs_classified - total.seqs_unique;
+    const double avg_seq_matches =
+        total.seqs_classified ? ( total.matches / static_cast< double >( total.seqs_classified ) ) : 0;
+    const double kmers_matched_perc =
+        total.kmers_matches ? total.kmers_matches / static_cast< double >( total.kmers_from_classified_seqs ) : 0;
+
+    out_sta << prefix << '\t';
+    out_sta << hierarchy_level << '\t';
+    out_sta << seq_processed << '\t';
+    out_sta << seq_unclassified << '\t';
+    out_sta << total.seqs_classified << '\t';
+    out_sta << total.seqs_classified / seq_processed << '\t';
+    out_sta << total.seqs_unique << '\t';
+    out_sta << total.seqs_unique / seq_processed << '\t';
+    out_sta << seq_multiple_matches << '\t';
+    out_sta << seq_multiple_matches / seq_processed << '\t';
+    out_sta << total.matches << '\t';
+    out_sta << avg_seq_matches << '\t';
+    out_sta << total.discarded_matches_filter << '\t';
+    out_sta << total.discarded_matches_fprquery << '\t';
+    out_sta << kmers_processed << '\t';
+    out_sta << total.kmers_from_classified_seqs << '\t';
+    out_sta << total.kmers_matches << '\t';
+    out_sta << kmers_matched_perc << '\n';
+}
+
+void write_stats( std::string                                     output_prefix,
+                  Stats&                                          stats,
+                  const std::map< std::string, HierarchyConfig >& parsed_hierarchy )
+{
+
+    for ( auto const& [prefix, total] : stats.total )
+    {
+        std::ofstream out_sta{ output_prefix + prefix + ".sta" };
+
+        out_sta << "prefix" << '\t';
+        out_sta << "hierarchy_label" << '\t';
+        out_sta << "seq_processed" << '\t';
+        out_sta << "seq_unclassified" << '\t';
+        out_sta << "seq_classified" << '\t';
+        out_sta << "seq_classified_perc" << '\t';
+        out_sta << "seq_unique_matches" << '\t';
+        out_sta << "seq_unique_matches_perc" << '\t';
+        out_sta << "seq_multiple_matches" << '\t';
+        out_sta << "seq_multiple_matches_perc" << '\t';
+        out_sta << "total_seq_matches" << '\t';
+        out_sta << "avg_matches_per_seq" << '\t';
+        out_sta << "dis_matches_rel_filter" << '\t';
+        out_sta << "dis_matches_fpr_query" << '\t';
+        out_sta << "kmers_proccessed" << '\t';
+        out_sta << "kmers_from_classified_seqs" << '\t';
+        out_sta << "kmers_matched" << '\t';
+        out_sta << "kmers_perc" << '\n';
+
+        const size_t seq_unclassified = total.seqs_processed - total.seqs_classified;
+        const double seq_processed    = total.seqs_processed > 0 ? static_cast< double >( total.seqs_processed )
+                                                                 : 1; // to not report nan on divisions
+
+        for ( auto const& h : parsed_hierarchy )
+        {
+            detail::write_stats_db( stats.hierarchy_total[h.first][prefix],
+                                    seq_processed,
+                                    seq_unclassified,
+                                    total.kmers_processed,
+                                    prefix,
+                                    h.first,
+                                    out_sta );
+        }
+
+        // If multiple hierarchy levels, print -total- line with sum
+        if ( parsed_hierarchy.size() > 1 )
+        {
+            detail::write_stats_db(
+                total, seq_processed, seq_unclassified, total.kmers_processed, prefix, "-total-", out_sta );
+        }
+        out_sta.close();
+    }
+}
 
 void parse_reads( SafeQueue< ReadBatches >& queue1, Stats& stats, Config const& config, TReadConfig& reads_config )
 {
@@ -1561,6 +1650,11 @@ bool ganon_classify( Config config )
 
     for ( auto& [prefix, file] : out_rep )
         file.close();
+
+    if ( config.output_stats )
+    {
+        detail::write_stats( config.output_prefix, stats, parsed_hierarchy );
+    }
 
     timeGanon.stop();
 

--- a/src/ganon-classify/GanonClassify.cpp
+++ b/src/ganon-classify/GanonClassify.cpp
@@ -1065,7 +1065,7 @@ void print_stats_db( const Total& total, double seq_processed, size_t seq_unclas
     std::cerr << "  " << total.seqs_unique << " with unique matches (" << ( total.seqs_unique / seq_processed ) * 100
               << "%)" << std::endl;
     std::cerr << "  " << seq_multiple_matches << " with multiple matches ("
-              << ( ( seq_multiple_matches ) / seq_processed ) * 100 << "%)" << std::endl;
+              << ( seq_multiple_matches / seq_processed ) * 100 << "%)" << std::endl;
     if ( seq_unclassified > 0 )
     {
         std::cerr << "" << seq_unclassified << " sequences unclassified (" << ( seq_unclassified / seq_processed ) * 100
@@ -1140,25 +1140,27 @@ void write_stats_db( const Total&   total,
     const double avg_seq_matches =
         total.seqs_classified ? ( total.matches / static_cast< double >( total.seqs_classified ) ) : 0;
     const double kmers_matched_perc =
-        total.kmers_matches ? total.kmers_matches / static_cast< double >( total.kmers_from_classified_seqs ) : 0;
+        total.kmers_matches ? ( total.kmers_matches / static_cast< double >( total.kmers_from_classified_seqs ) ) * 100
+                            : 0;
 
+    out_sta << std::fixed << std::setprecision( 6 );
     out_sta << prefix << '\t';
     out_sta << hierarchy_level << '\t';
-    out_sta << seq_processed << '\t';
+    out_sta << static_cast< size_t >( seq_processed ) << '\t';
     out_sta << seq_unclassified << '\t';
     out_sta << total.seqs_classified << '\t';
-    out_sta << total.seqs_classified / seq_processed << '\t';
+    out_sta << ( total.seqs_classified / seq_processed ) * 100 << '\t';
     out_sta << total.seqs_unique << '\t';
-    out_sta << total.seqs_unique / seq_processed << '\t';
+    out_sta << ( total.seqs_unique / seq_processed ) * 100 << '\t';
     out_sta << seq_multiple_matches << '\t';
-    out_sta << seq_multiple_matches / seq_processed << '\t';
+    out_sta << ( seq_multiple_matches / seq_processed ) * 100 << '\t';
     out_sta << total.matches << '\t';
     out_sta << avg_seq_matches << '\t';
     out_sta << total.discarded_matches_filter << '\t';
     out_sta << total.discarded_matches_fprquery << '\t';
     out_sta << kmers_processed << '\t';
-    out_sta << total.kmers_from_classified_seqs << '\t';
     out_sta << total.kmers_matches << '\t';
+    out_sta << total.kmers_from_classified_seqs << '\t';
     out_sta << kmers_matched_perc << '\n';
 }
 
@@ -1186,9 +1188,9 @@ void write_stats( std::string                                     output_prefix,
         out_sta << "dis_matches_rel_filter" << '\t';
         out_sta << "dis_matches_fpr_query" << '\t';
         out_sta << "kmers_proccessed" << '\t';
-        out_sta << "kmers_from_classified_seqs" << '\t';
         out_sta << "kmers_matched" << '\t';
-        out_sta << "kmers_perc" << '\n';
+        out_sta << "kmers_from_classified_seqs" << '\t';
+        out_sta << "kmers_matched_perc" << '\n';
 
         const size_t seq_unclassified = total.seqs_processed - total.seqs_classified;
         const double seq_processed    = total.seqs_processed > 0 ? static_cast< double >( total.seqs_processed )

--- a/src/ganon-classify/include/ganon-classify/Config.hpp
+++ b/src/ganon-classify/include/ganon-classify/Config.hpp
@@ -36,6 +36,7 @@ public:
     bool output_lca          = false;
     bool output_all          = false;
     bool output_unclassified = false;
+    bool output_stats        = false;
     bool output_single       = false;
 
     bool        hibf          = false;
@@ -272,6 +273,7 @@ inline std::ostream& operator<<( std::ostream& stream, const Config& config )
     stream << "--output-lca          " << config.output_lca << newl;
     stream << "--output-all          " << config.output_all << newl;
     stream << "--output-unclassified " << config.output_unclassified << newl;
+    stream << "--output-stats        " << config.output_stats << newl;
     stream << "--output-single       " << config.output_single << newl;
     stream << "--hibf                " << config.hibf << newl;
     stream << "--threads             " << config.threads << newl;

--- a/src/ganon/classify.py
+++ b/src/ganon/classify.py
@@ -51,6 +51,7 @@ def classify(cfg):
             "--output-lca" if cfg.multiple_matches == "lca" and cfg.output_one else "",
             "--output-all" if cfg.output_all or cfg.multiple_matches == "em" else "",
             "--output-unclassified" if cfg.output_unclassified else "",
+            "--output-stats" if cfg.output_stats else "",
             "--output-single" if cfg.output_single else "",
             "--threads " + str(cfg.threads) if cfg.threads else "",
             "--n-reads " + str(cfg.n_reads) if cfg.n_reads is not None else "",

--- a/src/ganon/config.py
+++ b/src/ganon/config.py
@@ -670,6 +670,11 @@ class Config:
             help="Output a file with unclassified read headers (.unc)",
         )
         classify_group_output.add_argument(
+            "--output-stats",
+            action="store_true",
+            help="Output a file with statistic of classification (.sta)",
+        )
+        classify_group_output.add_argument(
             "--output-single",
             action="store_true",
             help="When using multiple hierarchical levels, output everything in one file instead of one per hierarchy",

--- a/tests/ganon-classify/GanonClassify.test.cpp
+++ b/tests/ganon-classify/GanonClassify.test.cpp
@@ -24,6 +24,7 @@ GanonClassify::Config defaultConfig( const std::string prefix )
     cfg.output_prefix       = prefix;
     cfg.output_all          = true;
     cfg.output_lca          = true;
+    cfg.output_stats        = true;
     cfg.output_unclassified = true;
     cfg.threads             = 4;
     cfg.verbose             = false;
@@ -296,6 +297,21 @@ SCENARIO( "classifying reads without errors", "[ganon-classify][without-errors]"
             config_classify::Res res{ cfg };
             config_classify::sanity_check( cfg, res );
             REQUIRE_FALSE( std::filesystem::exists( prefix + ".all" ) );
+        }
+        SECTION( "without --output-stats" )
+        {
+            std::string prefix{ folder_prefix + "default_wo_output_stats" };
+            auto        cfg  = config_classify::defaultConfig( prefix );
+            cfg.output_stats = false;
+            cfg.ibf          = { base_prefix + ".ibf" };
+            cfg.single_reads = { folder_prefix + "readA.fasta" };
+            cfg.rel_cutoff   = { 0 };
+            cfg.rel_filter   = { 1 };
+
+            REQUIRE( GanonClassify::run( cfg ) );
+            config_classify::Res res{ cfg };
+            config_classify::sanity_check( cfg, res );
+            REQUIRE_FALSE( std::filesystem::exists( prefix + ".sta" ) );
         }
     }
 

--- a/tests/ganon/integration/test_classify.py
+++ b/tests/ganon/integration/test_classify.py
@@ -1,5 +1,5 @@
 import unittest
-
+from pathlib import Path
 
 from ganon.config import Config
 
@@ -166,6 +166,7 @@ class TestClassify(unittest.TestCase):
         params["output_one"] = True
         params["output_all"] = True
         params["output_unclassified"] = True
+        params["output_stats"] = True
 
         # Build config from params
         cfg = Config("classify", **params)
@@ -177,6 +178,12 @@ class TestClassify(unittest.TestCase):
         # General sanity check of results
         res = classify_sanity_check_and_parse(vars(cfg))
         self.assertIsNotNone(res, "ganon table has inconsistent results")
+
+        # Files exist and are not empty
+        self.assertTrue(Path(params["output_prefix"] + ".one").stat().st_size > 0)
+        self.assertTrue(Path(params["output_prefix"] + ".all").stat().st_size > 0)
+        self.assertTrue(Path(params["output_prefix"] + ".unc").stat().st_size > 0)
+        self.assertTrue(Path(params["output_prefix"] + ".sta").stat().st_size > 0)
 
     def test_multiple_matches_em(self):
         """


### PR DESCRIPTION
Add `--output-stats` to write an tabular file with statistics and totals from ganon-classify stderr log. The .sta contains the following fields:

```
prefix
hierarchy_label
seq_processed
seq_unclassified
seq_classified
seq_classified_perc
seq_unique_matches
seq_unique_matches_perc
seq_multiple_matches
seq_multiple_matches_perc
matches
avg_matches_ref_seq
dis_matches_rel_filter
dis_matches_fpr_query
kmers_proccessed
kmers_matched
kmers_from_classified_seqs
kmers_matched_perc
```