### PR TITLE
ganon v2.4.2

### DIFF
--- a/docs/handson_20260617.md
+++ b/docs/handson_20260617.md
@@ -1,0 +1,92 @@
+# ganon2 hands-on - 2026-06-17
+
+This tutorial introduces practical approaches to creating and utilising databases for metagenomics classification with Ganon2. It will cover both basic and advanced options, as well as common pitfalls in metagenomics classification. Topics include selecting databases and taxonomies, choosing parameters and thresholds, and interpreting results.
+
+By the end, you should have acquired the knowledge required to create your own databases and implement suitable classification strategies to improve your metagenomics analyses.
+
+The tutorial uses real human skin metagenomics samples and enhances their default classification using metagenome-assembled genomes. Reports and a final table of counts are created, and the results are visualised using taxonomic bars and a heatmap.
+
+## Prepare files and tools
+
+### Download files
+
+Download prepared files and unpack in a working directory of choice:
+
+```bash
+mkdir ganon_handson_20260617
+cd ganon_handson_20260617
+wget ...
+tar xf ...
+```
+
+### Install tools
+
+- [ganon](https://github.com/pirovc/ganon)
+
+```bash
+conda create -c conda-forge -c bioconda -n ganonenv ganon
+```
+
+- [GRIMER](https://github.com/pirovc/grimer) (for visualization)
+
+```bash
+conda create -n grimerenv -c conda-forge "python=3.9" "biom-format=2.1.16" "numpy=1.23.5"
+conda activate grimerenv
+conda install "grimer=1.1.0"
+conda deactivate
+```
+
+### Useful alias to check tsv files
+
+```bash
+# c: like cat but with aligned tabs for tsv files
+alias c="column -s$'\t' -t"
+
+# cless: like less with c function above
+cless() {
+    if [ -z "$1" ]; then
+        c | less -SN
+    else
+        c "$1" | less -SN
+    fi
+}
+```
+
+If you find them useful, you can add those commands to your `~/.bashrc` to have it available at all times.
+
+### Check installed version and files
+
+Ganon:
+
+```bash
+$ conda activate ganonenv
+$ ganon --version
+version: ganon 2.4.1
+$ genome_updater.sh | grep -m 1 "v" | tr -d ' '
+v0.8.0
+$ python -c "import multitax; print(multitax.__version__)"
+1.6.0
+```
+
+GRIMER:
+
+```bash
+$ conda activate grimerenv
+$ grimer --version | grep "grimer"
+grimer 1.1.0
+``` 
+
+Files:
+
+```bash
+$ ls -1 *
+ganon_handson_files_20260617.tar.gz
+
+files:
+aux
+gcmeta
+mgnify
+reads
+rs_bac_cg_ncbi_t1f_files
+rs_bac_gtdb_t1f_files
+```

--- a/docs/handson_20260617.md
+++ b/docs/handson_20260617.md
@@ -61,9 +61,9 @@ Ganon:
 ```bash
 $ conda activate ganonenv
 $ ganon --version
-version: ganon 2.4.1
+version: ganon 2.4.2
 $ genome_updater.sh | grep -m 1 "v" | tr -d ' '
-v0.8.0
+v0.8.1
 $ python -c "import multitax; print(multitax.__version__)"
 1.6.0
 ```

--- a/docs/params.md
+++ b/docs/params.md
@@ -7,7 +7,7 @@ usage: ganon [-h] [-v]
 - - - - - - - - - -
    _  _  _  _  _   
   (_|(_|| |(_)| |  
-   _|   v. 2.4.1
+   _|   v. 2.4.2
 - - - - - - - - - -
 
 positional arguments:
@@ -288,8 +288,8 @@ post-processing/report arguments:
                         class order family genus species assembly]. (default: [])
   --min-count           Minimum percentage/counts to report an taxa (.tre) [use values between 0-1 for percentage, >1
                         for counts] (default: 5e-05)
-  --report-type         Type of report (.tre) [abundance, reads, matches, dist, corr]. More info in 'ganon report'.
-                        (default: abundance)
+  --report-type         Type of report (.tre) [abundance, reads, matches, dist, dist+abundance]. More info in 'ganon
+                        report'. (default: abundance)
   --skip-report         Disable tree-like report (.tre) at the end of classification. Can be done later with 'ganon
                         report'. (default: False)
 
@@ -394,11 +394,10 @@ output arguments:
   -f, --output-format   Output format [text, tsv, csv, bioboxes]. text outputs a tabulated formatted text file for
                         better visualization. bioboxes is the the CAMI challenge profiling format (only
                         percentage/abundances are reported). (default: tsv)
-  -t, --report-type     Type of report [abundance, reads, matches, dist, corr]. 'abundance' -> tax. abundance (re-
-                        distribute read counts and correct by genome size), 'reads' -> sequence abundance, 'matches' ->
-                        report all unique and shared matches, 'dist' -> like reads with re-distribution of shared read
-                        counts only, 'corr' -> like abundance without re-distribution of shared read counts (default:
-                        abundance)
+  -t, --report-type     Type of report [abundance, reads, matches, dist, dist+abundance]. 'abundance' -> tax. abundance
+                        (correct by genome size), 'reads' -> sequence abundance, 'matches' -> report all unique and
+                        shared matches, 'dist' -> simple re-distribution of shared reads based on unique reads,
+                        'dist+abundance' -> like dist corrected by genome size (default: abundance)
   -r, --ranks [ ...]    Ranks to report ['', 'all', custom list]. 'all' for all possible ranks. empty for default ranks
                         [domain phylum class order family genus species assembly]. (default: [])
   -s, --sort            Sort report by [rank, lineage, count, unique]. Default: rank (with custom --ranks) or lineage

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -24,9 +24,9 @@ Details on unique, shared and children values can be found [here](outputfiles.md
 Several reports are available with `--report-type`: `reads`, `abundance`, `dist`, `corr`, `matches`:
 
 - `reads` reports **sequence abundances** which are the basic proportion of reads classified in the sample.
-- `abundance` will convert sequence abundance into **taxonomic abundances** by re-distributing read counts among leaf nodes and correcting by genome size. The re-distribution applies for reads classified with a LCA assignment and it is proportional to the number of unique matches of leaf nodes available in the ganon database (relative to the LCA node). If EM was previously used to re-distribute reads, will only correct for sequence abundance (same as `corr`). Genome size is estimated based on [NCBI or GTDB auxiliary files](custom_databases.md#genome-sizes-genome-size-files). Genome size correction is applied by rank based on default ranks only (superkingdom phylum class order family genus species assembly). Read counts in intermediate ranks will be corrected based on the closest parent default rank and re-assigned to its original rank.
-- `dist` is the same of `reads` with read count re-distribution
-- `corr` is the same of `reads` with correction by genome size
+- `abundance` will convert sequence abundance into **taxonomic abundances** by correcting by genome size. Genome size is estimated based on [NCBI or GTDB auxiliary files](custom_databases.md#genome-sizes-genome-size-files). Genome size correction is applied by rank based on default ranks only (domain phylum class order family genus species assembly). Read counts in intermediate ranks will be corrected based on the closest parent default rank and re-assigned to its original rank.
+- `dist` will re-distribute read counts among leaf nodes. The re-distribution is proportional to the number of unique matches of leaf nodes available in the ganon database. This is a simpler version of the EM algorithm, with just one iteration. The full EM algorithm (`ganon reassign`) is recommended over this option.
+- `dist+abundance` is the same of `dist` with correction by genome size.
 - `matches` will report the total number of matches classified, either unique or shared. *This option will output the total number of matches instead the total number of reads*
 
 ## Filter and format

--- a/docs/start.md
+++ b/docs/start.md
@@ -51,7 +51,7 @@ The most important parameters and trade-offs to be aware of when using ganon:
 
 ### ganon report
 
-- `--report-type`: reports either taxonomic, sequence or matches abundances. Use `corr` or `abundance` for taxonomic profiling, `reads` or `dist` for sequence profiling and `matches` to report a summary of all matches.
+- `--report-type`: reports either taxonomic, sequence or matches abundances. Use `abundance` for taxonomic profiling, `reads` for sequence profiling, or `matches` to report a summary of all matches.
 - `--min-count`: cutoff to discard underrepresented taxa. Useful to remove the common long tail of spurious matches and false positives when performing classification. Values between `0.0001` (0.01%) and `0.001` (0.1%) improved sensitivity and precision in our evaluations. The higher the value, the more precise the outcome, with a sensitivity loss. Alternatively `--top-percentile` can be used to keep a relative amount of taxa instead a hard cutoff.
 
 The numeric values above are averages from several experiments with different sample types and database contents. They may not work as expected for your data. If you are not sure which values to use or see something unexpected, please open an [issue](https://github.com/pirovc/ganon/issues){target="_blank"}.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
     - Reports (ganon report): reports.md
     - Table (ganon table): table.md
     - Output files: outputfiles.md
+    - ganon2 hands-on 2026 06 17: handson_20260617.md
 markdown_extensions:
   - tables
   - attr_list

--- a/src/ganon/config.py
+++ b/src/ganon/config.py
@@ -68,7 +68,7 @@ class Config:
         "species",
         "assembly",
     ]
-    choices_report_type = ["abundance", "reads", "matches", "dist", "corr"]
+    choices_report_type = ["abundance", "reads", "matches", "dist", "dist+abundance"]
     choices_multiple_matches = ["em", "lca", "skip"]
     choices_report_output = ["text", "tsv", "csv", "bioboxes"]
     choices_mode = ["avg", "smaller", "smallest", "faster", "fastest"]
@@ -899,7 +899,7 @@ class Config:
             default="abundance",
             help="Type of report ["
             + ", ".join(self.choices_report_type)
-            + "]. 'abundance' -> tax. abundance (re-distribute read counts and correct by genome size), 'reads' -> sequence abundance, 'matches' -> report all unique and shared matches, 'dist' -> like reads with re-distribution of shared read counts only, 'corr' -> like abundance without re-distribution of shared read counts",
+            + "]. 'abundance' -> tax. abundance (correct by genome size), 'reads' -> sequence abundance, 'matches' -> report all unique and shared matches, 'dist' -> simple re-distribution of shared reads based on unique reads, 'dist+abundance' -> like dist corrected by genome size",
             choices=self.choices_report_type,
         )
         report_group_output.add_argument(

--- a/src/ganon/report.py
+++ b/src/ganon/report.py
@@ -38,7 +38,7 @@ def report(cfg):
 
         tax = CustomTx(files=dbp, cols=["node", "parent", "rank", "name"], **tax_args)
 
-        if cfg.report_type in ["abundance", "corr"]:
+        if cfg.report_type in ["abundance", "dist+abundance"]:
             try:
                 genome_sizes = parse_genome_size_tax(dbp)
             except ValueError:
@@ -68,7 +68,7 @@ def report(cfg):
             )
 
         # In case no tax was provided, generate genome sizes (for the full tree)
-        if cfg.report_type in ["abundance", "corr"]:
+        if cfg.report_type in ["abundance", "dist+abundance"]:
             genome_sizes = get_genome_size(cfg, tax.leaves(), tax, "./")
 
     default_ranks = [tax.root_name] + cfg.choices_default_ranks
@@ -254,7 +254,7 @@ def build_report(
     tax.build_lineages()
 
     # Re-distribute lca reads to leaf nodes based on unique matches or shared
-    if cfg.report_type in ["abundance", "dist"]:
+    if cfg.report_type in ["dist", "dist+abundance"]:
         redistribute_shared_reads(merged_rep, tax)
 
     # Count data from merged_rep into a final count per target, depending on report type
@@ -263,7 +263,7 @@ def build_report(
     # Cummulatively sum leaf counts to its lineage parents
     tree_cum_counts = cummulative_sum_tree(target_counts, tax)
 
-    if cfg.report_type in ["abundance", "corr"]:
+    if cfg.report_type in ["abundance", "dist+abundance"]:
         # Correct counts based on estimated genome sizes for default ranks
         # returns tree_cum_counts with corrected FRACTION of counts and use it to calculate the abundances
         # still reports original counts for user

--- a/tests/ganon/integration/test_report.py
+++ b/tests/ganon/integration/test_report.py
@@ -249,13 +249,13 @@ class TestReport(unittest.TestCase):
             "ganon report failed filtering with --max-count",
         )
 
-    def test_report_type_abundance(self):
+    def test_report_type_dist_abundance(self):
         """
         Test run with report_type abundance
         """
         params = self.default_params.copy()
-        params["output_prefix"] = self.results_dir + "test_report_type_abundance"
-        params["report_type"] = "abundance"
+        params["output_prefix"] = self.results_dir + "test_report_type_dist_abundance"
+        params["report_type"] = "dist+abundance"
 
         # Build config from params
         cfg = Config("report", **params)
@@ -270,7 +270,7 @@ class TestReport(unittest.TestCase):
         # Re-distribution and genome correction, shared sum bigger then 0
         self.assertTrue(
             res["tre_pd"][res["tre_pd"]["rank"] == "assembly"]["shared"].sum() > 0,
-            "ganon report has wrong output for --report_type abundance",
+            "ganon report has wrong output for --report_type dist+abundance",
         )
 
     def test_report_type_reads(self):

--- a/tests/ganon/integration/test_report.py
+++ b/tests/ganon/integration/test_report.py
@@ -321,13 +321,13 @@ class TestReport(unittest.TestCase):
             "ganon report has wrong output for --report_type matches",
         )
 
-    def test_report_type_corr(self):
+    def test_report_type_abundance(self):
         """
         Test run with report_type abundance
         """
         params = self.default_params.copy()
-        params["output_prefix"] = self.results_dir + "test_report_type_corr"
-        params["report_type"] = "corr"
+        params["output_prefix"] = self.results_dir + "test_report_type_abundance"
+        params["report_type"] = "abundance"
 
         # Build config from params
         cfg = Config("report", **params)
@@ -343,12 +343,12 @@ class TestReport(unittest.TestCase):
         self.assertEqual(
             res["tre_pd"][res["tre_pd"]["rank"] == "assembly"]["shared"].sum(),
             0,
-            "ganon report has wrong output for --report_type corr",
+            "ganon report has wrong output for --report_type abundance",
         )
 
     def test_report_type_dist(self):
         """
-        Test run with report_type abundance
+        Test run with report_type dist
         """
         params = self.default_params.copy()
         params["output_prefix"] = self.results_dir + "test_report_type_dist"
@@ -447,8 +447,8 @@ class TestReport(unittest.TestCase):
         )
 
         params = self.default_params.copy()
-        params["output_prefix"] = self.results_dir + "test_ranks_all_corr"
-        params["report_type"] = "corr"
+        params["output_prefix"] = self.results_dir + "test_ranks_all_abundance"
+        params["report_type"] = "abundance"
         params["ranks"] = "all"
         cfg = Config("report", **params)
         self.assertTrue(


### PR DESCRIPTION
- Small fixes and renaming of `--report-type` to avoid confusion
  - `reads` -> same
  - `matches` -> same 
  - `dist` -> same
  - `abundance` -> will now only correct for genome size (old behavior of `corr`)
  - `dist+abundance` -> (new) will perform basic re-distribution and correct for genome size (old behavior of `abundance`)
  - `corr` -> removed
